### PR TITLE
Do not reuse cURL sockets

### DIFF
--- a/lib/diaspora_federation/federation/sender/hydra_wrapper.rb
+++ b/lib/diaspora_federation/federation/sender/hydra_wrapper.rb
@@ -11,12 +11,13 @@ module DiasporaFederation
         # @return [Hash] hydra opts
         def self.hydra_opts
           @hydra_opts ||= {
-            maxredirs: DiasporaFederation.http_redirect_limit,
-            timeout:   DiasporaFederation.http_timeout,
-            method:    :post,
-            verbose:   DiasporaFederation.http_verbose,
-            cainfo:    DiasporaFederation.certificate_authorities,
-            headers:   {
+            maxredirs:    DiasporaFederation.http_redirect_limit,
+            timeout:      DiasporaFederation.http_timeout,
+            method:       :post,
+            verbose:      DiasporaFederation.http_verbose,
+            cainfo:       DiasporaFederation.certificate_authorities,
+            forbid_reuse: true,
+            headers:      {
               "Expect"            => "",
               "Transfer-Encoding" => "",
               "User-Agent"        => DiasporaFederation.http_user_agent


### PR DESCRIPTION
This patch sets CURLOPT_FORBID_REUSE, which tells cURL to close all connections when they are done. By default, connections are held open for later use unless explicitly closed or expired by a timeout. This can improve performance if the same instance is used for multiple requests to a single host.

We never have that: a host receives only one message per queue job, so keeping the socket opened for 60 seconds (the default timeout) is totally useless.

In addition, keeping the sockets open can cause problems for larger instances with fast workers and a lot of jobs. Mainly, https://github.com/diaspora/diaspora/issues/6485 is caused by this very issue, which is resolved by this as well.

This also **may** resolve some of the memory bloat described in https://github.com/diaspora/diaspora/issues/6763, but we would have to dig further into that to confirm or deny.