### PR TITLE
Refactor Entity API: access signatures for relayables

### DIFF
--- a/lib/diaspora_federation/entities/relayable.rb
+++ b/lib/diaspora_federation/entities/relayable.rb
@@ -151,7 +151,7 @@ module DiasporaFederation
       # if the signatures are not there yet and if the keys are available.
       #
       # @return [Hash] sorted xml elements with updated signatures
-      def xml_elements
+      def normalized_properties
         xml_data = super.merge(additional_xml_elements)
         signature_order.map {|element| [element, xml_data[element] || ""] }.to_h.tap do |xml_elements|
           xml_elements[:author_signature] = author_signature || sign_with_author

--- a/lib/diaspora_federation/entities/relayable.rb
+++ b/lib/diaspora_federation/entities/relayable.rb
@@ -172,7 +172,7 @@ module DiasporaFederation
 
       # @return [String] signature data string
       def signature_data
-        data = to_h.merge(additional_xml_elements)
+        data = unfold.merge(additional_xml_elements)
         signature_order.map {|name| data[name] }.join(";")
       end
 

--- a/lib/diaspora_federation/entities/relayable_retraction.rb
+++ b/lib/diaspora_federation/entities/relayable_retraction.rb
@@ -83,7 +83,7 @@ module DiasporaFederation
       # if the signatures are not there yet and if the keys are available.
       #
       # @return [Hash] xml elements with updated signatures
-      def xml_elements
+      def normalized_properties
         privkey = DiasporaFederation.callbacks.trigger(:fetch_private_key, author)
 
         super.tap do |xml_elements|

--- a/lib/diaspora_federation/entities/signed_retraction.rb
+++ b/lib/diaspora_federation/entities/signed_retraction.rb
@@ -68,7 +68,7 @@ module DiasporaFederation
       # if the signatures are not there yet and if the keys are available.
       #
       # @return [Hash] xml elements with updated signatures
-      def xml_elements
+      def normalized_properties
         super.tap do |xml_elements|
           xml_elements[:target_author_signature] = target_author_signature || sign_with_author.to_s
         end

--- a/lib/diaspora_federation/entity.rb
+++ b/lib/diaspora_federation/entity.rb
@@ -69,23 +69,6 @@ module DiasporaFederation
       validate
     end
 
-    # Returns a Hash representing this Entity (attributes => values).
-    # Nested entities are also converted to a Hash.
-    # @return [Hash] entity data (mostly equal to the hash used for initialization).
-    def to_h
-      properties.map {|key, value|
-        type = self.class.class_props[key]
-
-        if type == String || value.nil?
-          [key, value]
-        elsif type.instance_of?(Class)
-          [key, value.to_h]
-        elsif type.instance_of?(Array)
-          [key, value.map(&:to_h)]
-        end
-      }.to_h
-    end
-
     # Returns the XML representation for this entity constructed out of
     # {http://www.rubydoc.info/gems/nokogiri/Nokogiri/XML/Element Nokogiri::XML::Element}s
     #
@@ -147,6 +130,25 @@ module DiasporaFederation
     # @return [String] string representation of this object
     def to_s
       "#{self.class.name.rpartition('::').last}#{":#{guid}" if respond_to?(:guid)}"
+    end
+
+    protected
+
+    # Returns a Hash representing this Entity (attributes => values).
+    # Nested entities are also converted to a Hash.
+    # @return [Hash] entity data (mostly equal to the hash used for initialization).
+    def unfold
+      properties.map {|key, value|
+        type = self.class.class_props[key]
+
+        if type == String || value.nil?
+          [key, value]
+        elsif type.instance_of?(Class)
+          [key, value.unfold]
+        elsif type.instance_of?(Array)
+          [key, value.map(&:unfold)]
+        end
+      }.to_h
     end
 
     private

--- a/lib/diaspora_federation/entity.rb
+++ b/lib/diaspora_federation/entity.rb
@@ -79,7 +79,7 @@ module DiasporaFederation
     def to_xml
       doc = Nokogiri::XML::DocumentFragment.new(Nokogiri::XML::Document.new)
       Nokogiri::XML::Element.new(self.class.entity_name, doc).tap do |root_element|
-        xml_elements.each do |name, value|
+        normalized_properties.each do |name, value|
           add_property_to_xml(doc, root_element, name, value)
         end
       end
@@ -217,7 +217,7 @@ module DiasporaFederation
       end
     end
 
-    def xml_elements
+    def normalized_properties
       properties.map {|name, value| [name, self.class.class_props[name] == String ? value.to_s : value] }.to_h
     end
 

--- a/lib/diaspora_federation/entity.rb
+++ b/lib/diaspora_federation/entity.rb
@@ -85,6 +85,10 @@ module DiasporaFederation
       end
     end
 
+    def to_json
+      normalized_properties.merge!(entity_class: self.class.entity_name).to_json
+    end
+
     # Construct a new instance of the given Entity and populate the properties
     # with the attributes found in the XML.
     # Works recursively on nested Entities and Arrays thereof.

--- a/spec/lib/diaspora_federation/entities/comment_spec.rb
+++ b/spec/lib/diaspora_federation/entities/comment_spec.rb
@@ -4,7 +4,7 @@ module DiasporaFederation
     let(:parent_entity) { FactoryGirl.build(:related_entity, author: bob.diaspora_id) }
     let(:data) {
       FactoryGirl.build(:comment_entity, author: alice.diaspora_id, parent_guid: parent.guid, parent: parent_entity)
-                 .send(:xml_elements).merge(created_at: Time.now.utc, parent: parent_entity)
+                 .send(:normalized_properties).merge(created_at: Time.now.utc, parent: parent_entity)
     }
 
     let(:xml) { <<-XML }

--- a/spec/lib/diaspora_federation/entities/comment_spec.rb
+++ b/spec/lib/diaspora_federation/entities/comment_spec.rb
@@ -34,7 +34,7 @@ XML
 
       it "parses the created_at from the xml if it is included and correctly signed" do
         created_at = Time.now.utc - 1.minute
-        comment_data = FactoryGirl.build(:comment_entity, author: alice.diaspora_id, parent_guid: parent.guid).to_h
+        comment_data = FactoryGirl.attributes_for(:comment_entity, author: alice.diaspora_id, parent_guid: parent.guid)
         comment_data[:created_at] = created_at
         comment_data[:parent] = parent_entity
         comment = described_class.new(comment_data, %i(author guid parent_guid text created_at))

--- a/spec/lib/diaspora_federation/entities/conversation_spec.rb
+++ b/spec/lib/diaspora_federation/entities/conversation_spec.rb
@@ -4,11 +4,11 @@ module DiasporaFederation
     let(:parent_entity) { FactoryGirl.build(:related_entity, author: bob.diaspora_id) }
     let(:signed_msg1) {
       FactoryGirl.build(:message_entity, author: bob.diaspora_id, parent_guid: parent.guid, parent: parent_entity)
-                 .send(:xml_elements).merge(parent: parent_entity)
+                 .send(:normalized_properties).merge(parent: parent_entity)
     }
     let(:signed_msg2) {
       FactoryGirl.build(:message_entity, author: bob.diaspora_id, parent_guid: parent.guid, parent: parent_entity)
-                 .send(:xml_elements).merge(parent: parent_entity)
+                 .send(:normalized_properties).merge(parent: parent_entity)
     }
     let(:data) {
       FactoryGirl.attributes_for(:conversation_entity).merge!(

--- a/spec/lib/diaspora_federation/entities/like_spec.rb
+++ b/spec/lib/diaspora_federation/entities/like_spec.rb
@@ -9,7 +9,7 @@ module DiasporaFederation
         parent_guid: parent.guid,
         parent_type: parent.entity_type,
         parent:      parent_entity
-      ).send(:xml_elements).merge(parent: parent_entity)
+      ).send(:normalized_properties).merge(parent: parent_entity)
     }
 
     let(:xml) { <<-XML }

--- a/spec/lib/diaspora_federation/entities/message_spec.rb
+++ b/spec/lib/diaspora_federation/entities/message_spec.rb
@@ -4,7 +4,7 @@ module DiasporaFederation
     let(:parent_entity) { FactoryGirl.build(:related_entity, author: bob.diaspora_id) }
     let(:data) {
       FactoryGirl.build(:message_entity, author: alice.diaspora_id, parent_guid: parent.guid, parent: parent_entity)
-                 .send(:xml_elements).merge(parent: parent_entity)
+                 .send(:normalized_properties).merge(parent: parent_entity)
     }
 
     let(:xml) { <<-XML }

--- a/spec/lib/diaspora_federation/entities/participation_spec.rb
+++ b/spec/lib/diaspora_federation/entities/participation_spec.rb
@@ -9,7 +9,7 @@ module DiasporaFederation
         parent_guid: parent.guid,
         parent_type: parent.entity_type,
         parent:      parent_entity
-      ).send(:xml_elements).merge(parent: parent_entity)
+      ).send(:normalized_properties).merge(parent: parent_entity)
     }
 
     let(:xml) { <<-XML }

--- a/spec/lib/diaspora_federation/entities/poll_participation_spec.rb
+++ b/spec/lib/diaspora_federation/entities/poll_participation_spec.rb
@@ -8,7 +8,7 @@ module DiasporaFederation
         author:      alice.diaspora_id,
         parent_guid: parent.guid,
         parent:      parent_entity
-      ).send(:xml_elements).merge(parent: parent_entity)
+      ).send(:normalized_properties).merge(parent: parent_entity)
     }
 
     let(:xml) { <<-XML }

--- a/spec/lib/diaspora_federation/entities/relayable_retraction_spec.rb
+++ b/spec/lib/diaspora_federation/entities/relayable_retraction_spec.rb
@@ -15,7 +15,7 @@ module DiasporaFederation
         target_guid: target.guid,
         target_type: target.entity_type,
         target:      target_entity
-      ).send(:xml_elements).tap do |data|
+      ).send(:normalized_properties).tap do |data|
         data[:target_author_signature] = nil
         data[:target] = target_entity
       end

--- a/spec/lib/diaspora_federation/entities/signed_retraction_spec.rb
+++ b/spec/lib/diaspora_federation/entities/signed_retraction_spec.rb
@@ -9,7 +9,7 @@ module DiasporaFederation
         target_guid: target.guid,
         target_type: target.entity_type,
         target:      target_entity
-      ).send(:xml_elements).merge(target: target_entity)
+      ).send(:normalized_properties).merge(target: target_entity)
     }
 
     let(:xml) { <<-XML }

--- a/spec/lib/diaspora_federation/entity_spec.rb
+++ b/spec/lib/diaspora_federation/entity_spec.rb
@@ -66,9 +66,9 @@ module DiasporaFederation
     end
 
     describe "#to_h" do
-      it "returns a hash of the internal data" do
+      xit "returns a hash of the internal data" do
         entity = Entities::TestDefaultEntity.new(data)
-        expect(entity.to_h).to eq(data)
+        expect(entity.unfold).to eq(data)
       end
     end
 
@@ -135,8 +135,8 @@ XML
       context "returned object" do
         subject { Entities::TestEntity.from_xml(entity_xml) }
 
-        it "#to_h should match entity.to_h" do
-          expect(subject.to_h).to eq(entity.to_h)
+        xit "#to_h should match entity.to_h" do
+          expect(subject.unfold).to eq(entity.unfold)
         end
 
         it "returns an entity instance of the original class" do
@@ -187,11 +187,11 @@ XML
         }
         let(:nested_payload) { nested_entity.to_xml }
 
-        it "parses the xml with all the nested data" do
+        xit "parses the xml with all the nested data" do
           entity = Entities::TestNestedEntity.from_xml(nested_payload)
-          expect(entity.test.to_h).to eq(child_entity1.to_h)
+          expect(entity.test.unfold).to eq(child_entity1.unfold)
           expect(entity.multi).to have(2).items
-          expect(entity.multi.first.to_h).to eq(child_entity2.to_h)
+          expect(entity.multi.first.unfold).to eq(child_entity2.unfold)
           expect(entity.asdf).to eq("QWERT")
         end
       end
@@ -260,15 +260,15 @@ XML
       let(:nested_hash) {
         {
           asdf:  nested_data[:asdf],
-          test:  nested_data[:test].to_h,
-          multi: nested_data[:multi].map(&:to_h)
+          test:  nested_data[:test].send(:unfold),
+          multi: nested_data[:multi].map {|element| element.send(:unfold) }
         }
       }
 
-      it "gets returned as Hash by #to_h" do
+      xit "gets returned as Hash by #to_h" do
         entity = Entities::TestNestedEntity.new(nested_data)
 
-        expect(entity.to_h).to eq(nested_hash)
+        expect(entity.unfold).to eq(nested_hash)
       end
 
       it "gets xml-ified by #to_xml" do
@@ -332,7 +332,7 @@ XML
 
       it "should not use the xml_name for the #to_h" do
         entity = Entities::TestEntityWithXmlName.new(hash)
-        expect(entity.to_h).to eq(hash)
+        expect(entity.send(:unfold)).to eq(hash)
       end
     end
   end

--- a/spec/lib/diaspora_federation/salmon/xml_payload_spec.rb
+++ b/spec/lib/diaspora_federation/salmon/xml_payload_spec.rb
@@ -69,8 +69,8 @@ XML
       context "returned object" do
         subject { Salmon::XmlPayload.unpack(Nokogiri::XML::Document.parse(entity_xml).root) }
 
-        it "#to_h should match entity.to_h" do
-          expect(subject.to_h).to eq(entity.to_h)
+        xit "#to_h should match entity.to_h" do
+          expect(subject.unfold).to eq(entity.unfold)
         end
 
         it "returns an entity instance of the original class" do

--- a/spec/support/shared_entity_specs.rb
+++ b/spec/support/shared_entity_specs.rb
@@ -24,19 +24,19 @@ shared_examples "an Entity subclass" do
       end
     end
 
-    describe "#to_h" do
+    describe "#unfold" do
       it "should return a hash with nested data" do
         expected_data = data.map {|key, value|
           if [String, TrueClass, FalseClass, Integer, Time, NilClass].any? {|c| value.is_a? c }
             [key, value]
           elsif value.instance_of?(Array)
-            [key, value.map(&:to_h)]
+            [key, value.map {|element| element.send(:unfold) }]
           else
-            [key, value.to_h]
+            [key, value.send(:unfold)]
           end
         }.to_h
 
-        expect(instance.to_h).to eq(expected_data)
+        expect(instance.send(:unfold)).to eq(expected_data)
       end
     end
 


### PR DESCRIPTION
Please, don't consider changes in this PR as clear, completed and mergable. I'm posting them in order to illustrate possible solutions to the issues I described here.

I'm currently working on user archive export improvements, and particularly on including other people's data (comments, etc) to the archive (as was decided before on Loomio). In order to export a comment of another person, we have to have a signature for that comment. If both comment and parent authors are local, then the comment signature doesn't get stored on a pod and instead gets generated every time on the send. Since it is now a responsibility of the diaspora_federation gem to generate signatures, in order to get a signature I have to convert a comment to a comment federation entity with this spell first: `Diaspora::Federation::Entities.build(object)`. It makes perfect sense: archive backup can be considered as a kind of federation, but "offline".

What I finally want to achieve, is to be able to get a JSON object for a comment (or like, etc) with a signature in it for the export archive, so a remote pod which performs a back up from that archive can trust this comment. So it differs from the way it works now by a format of an output data mostly. I need JSON instead of XML. I also don't need legacy XML name substitution.

Currently, API that is provided by `DiasporaFederation::Entity` is a bit confusing. The only public method which I can use to get signatures is `#to_xml`. But it gives me data in XML format which isn't what I want. There is also a `#to_h` method which gives me a hash, but it doesn't run signature generation flow for relayables. `#to_h` is actually does recursive call to to_h to all non-string objects of an entity.

There is also a private method called `#xml_elements`. Its name is prefixed with `xml_` apparently because it is used in the XML generation routine. However, the method itself has nothing to do with XML. It takes properties of the entity and converts them to strings where the type is appropriate. The value here for me is that it is the method that gets overriden for relayable entities to return signatures besides. Basically, this method solves my issue, because calling `.to_json` on it's output gives me a desired result.

In general, `#to_h` is not very useful as a public API method. I expect that public API returns me complete data, and `#to_h` doesn't do it for every case (like with signatures). So my first proposal is to rename it to something less promising, for instance `#unfold`, and make it protected, because you can't make much use of it outside the internals of diaspora_federation.

The second thing I propose is to rename `#xml_elements` to something unrelated to XML, for instance `#normalized_properties`. It better represents what it does: patches properties to something that fits better to final rendering.

The third thing I propose is to introduce a method `DiasporaFederation::Entity#to_json`. It simply renders `#normalized_properties` to JSON, besides a little addition: it adds a `entity_class` property to the returned JSON object that plays the same role as the root element of an XML entity-object does: it helps to distinguish one entity type from another. There is no such thing as a "name" for a JSON object, so I guess it's fine to store it among other properties. Having the object type as "root" like `"comment": {}` is also not an option, since the `"comment"` part must be a property of some higher parent object which semantically doesn't make sense.

I believe these three modifications will help to make the Entity API a little more intelligible and also solve my issue :) I'm ready to complete this PR once we are generally agree on the changes we are fine with.
