### PR TITLE
Replace ^ and $ with \A \z in patterns

### DIFF
--- a/lib/diaspora_federation/discovery/host_meta.rb
+++ b/lib/diaspora_federation/discovery/host_meta.rb
@@ -76,7 +76,7 @@ module DiasporaFederation
       # @param [String] url validation subject
       # @return [Boolean] validation result
       private_class_method def self.webfinger_url_valid?(url)
-        !url.nil? && url.instance_of?(String) && url =~ %r{^https?:\/\/.*\/.*\{uri\}.*}i
+        !url.nil? && url.instance_of?(String) && url =~ %r{\Ahttps?:\/\/.*\/.*\{uri\}.*}i
       end
 
       # Gets the webfinger url from an XRD data structure

--- a/lib/diaspora_federation/entity.rb
+++ b/lib/diaspora_federation/entity.rb
@@ -135,8 +135,8 @@ module DiasporaFederation
     # @param [String] entity_name "snake_case" class name
     # @return [Class] entity class
     def self.entity_class(entity_name)
-      raise InvalidEntityName, "'#{entity_name}' is invalid" unless entity_name =~ /^[a-z]*(_[a-z]*)*$/
-      class_name = entity_name.sub(/^[a-z]/, &:upcase)
+      raise InvalidEntityName, "'#{entity_name}' is invalid" unless entity_name =~ /\A[a-z]*(_[a-z]*)*\z/
+      class_name = entity_name.sub(/\A[a-z]/, &:upcase)
       class_name.gsub!(/_([a-z])/) { Regexp.last_match[1].upcase }
 
       raise UnknownEntity, "'#{class_name}' not found" unless Entities.const_defined?(class_name)
@@ -317,10 +317,10 @@ module DiasporaFederation
           nil
         end
       when :integer
-        text.to_i if text =~ /^\d+$/
+        text.to_i if text =~ /\A\d+\z/
       when :boolean
-        return true if text =~ /^(true|t|yes|y|1)$/i
-        false if text =~ /^(false|f|no|n|0)$/i
+        return true if text =~ /\A(true|t|yes|y|1)\z/i
+        false if text =~ /\A(false|f|no|n|0)\z/i
       else
         text
       end

--- a/lib/diaspora_federation/federation/fetcher.rb
+++ b/lib/diaspora_federation/federation/fetcher.rb
@@ -21,7 +21,7 @@ module DiasporaFederation
       end
 
       private_class_method def self.entity_name(class_name)
-        return class_name if class_name =~ /^[a-z]*(_[a-z]*)*$/
+        return class_name if class_name =~ /\A[a-z]*(_[a-z]*)*\z/
 
         raise DiasporaFederation::Entity::UnknownEntity, class_name unless Entities.const_defined?(class_name)
 


### PR DESCRIPTION
One should use \A and \z unless explicitly wants the line-wise behavior.