### PR TITLE
Use enriched_properties instead of properties in Entity#to_h

### DIFF
--- a/lib/diaspora_federation/entities/message.rb
+++ b/lib/diaspora_federation/entities/message.rb
@@ -33,6 +33,11 @@ module DiasporaFederation
         sender == author || (sender == parent_author && verify_author_signature)
       end
 
+      # @deprecated remove after {Message} doesn't include {Relayable} anymore
+      def to_h
+        super.tap {|hash| hash[:created_at] = created_at.utc.iso8601 }
+      end
+
       private
 
       # @deprecated remove after {Message} doesn't include {Relayable} anymore

--- a/lib/diaspora_federation/entity.rb
+++ b/lib/diaspora_federation/entity.rb
@@ -73,7 +73,7 @@ module DiasporaFederation
     # Nested entities are also converted to a Hash.
     # @return [Hash] entity data (mostly equal to the hash used for initialization).
     def to_h
-      properties.map {|key, value|
+      enriched_properties.map {|key, value|
         type = self.class.class_props[key]
 
         if type.instance_of?(Symbol) || value.nil?
@@ -302,13 +302,13 @@ module DiasporaFederation
     private_class_method def self.parse_string_from_node(name, type, root_node)
       node = root_node.xpath(name.to_s)
       node = root_node.xpath(xml_names[name].to_s) if node.empty?
-      parse_property(type, node.first.text) if node.any?
+      parse_string(type, node.first.text) if node.any?
     end
 
     # @param [Symbol] type target type to parse
     # @param [String] text data as string
     # @return [String, Boolean, Integer, Time] data
-    private_class_method def self.parse_property(type, text)
+    private_class_method def self.parse_string(type, text)
       case type
       when :timestamp
         begin

--- a/lib/diaspora_federation/test/factories.rb
+++ b/lib/diaspora_federation/test/factories.rb
@@ -31,7 +31,7 @@ module DiasporaFederation
             nickname "some_name"
             full_name "my name"
             first_name "my name"
-            last_name nil
+            last_name ""
             url "http://localhost:3000/"
             public_key
             photo_large_url "/assets/user/default.png"
@@ -53,7 +53,7 @@ module DiasporaFederation
           factory :profile_entity, class: DiasporaFederation::Entities::Profile do
             author { generate(:diaspora_id) }
             first_name "my name"
-            last_name nil
+            last_name ""
             image_url "/assets/user/default.png"
             image_url_medium "/assets/user/default.png"
             image_url_small "/assets/user/default.png"

--- a/spec/lib/diaspora_federation/entities/comment_spec.rb
+++ b/spec/lib/diaspora_federation/entities/comment_spec.rb
@@ -3,9 +3,14 @@ module DiasporaFederation
     let(:parent) { FactoryGirl.create(:post, author: bob) }
     let(:parent_entity) { FactoryGirl.build(:related_entity, author: bob.diaspora_id) }
     let(:data) {
-      add_signatures(
-        FactoryGirl.build(:comment_entity, author: alice.diaspora_id, parent_guid: parent.guid, parent: parent_entity)
-      )
+      FactoryGirl
+        .attributes_for(
+          :comment_entity,
+          author:      alice.diaspora_id,
+          parent_guid: parent.guid,
+          parent:      parent_entity,
+          created_at:  Time.now.utc
+        ).tap {|hash| add_signatures(hash) }
     }
 
     let(:xml) { <<-XML }
@@ -35,7 +40,7 @@ XML
 
       it "parses the created_at from the xml if it is included and correctly signed" do
         created_at = Time.now.utc.change(usec: 0) - 1.minute
-        comment_data = FactoryGirl.build(:comment_entity, author: alice.diaspora_id, parent_guid: parent.guid).to_h
+        comment_data = FactoryGirl.attributes_for(:comment_entity, author: alice.diaspora_id, parent_guid: parent.guid)
         comment_data[:created_at] = created_at
         comment_data[:parent] = parent_entity
         comment = described_class.new(comment_data, %i(author guid parent_guid text created_at))

--- a/spec/lib/diaspora_federation/entities/conversation_spec.rb
+++ b/spec/lib/diaspora_federation/entities/conversation_spec.rb
@@ -3,14 +3,20 @@ module DiasporaFederation
     let(:parent) { FactoryGirl.create(:conversation, author: bob) }
     let(:parent_entity) { FactoryGirl.build(:related_entity, author: bob.diaspora_id) }
     let(:signed_msg1) {
-      add_signatures(
-        FactoryGirl.build(:message_entity, author: bob.diaspora_id, parent_guid: parent.guid, parent: parent_entity)
-      )
+      FactoryGirl.attributes_for(
+        :message_entity,
+        author:      bob.diaspora_id,
+        parent_guid: parent.guid,
+        parent:      parent_entity
+      ).tap {|hash| add_signatures(hash, Entities::Message) }
     }
     let(:signed_msg2) {
-      add_signatures(
-        FactoryGirl.build(:message_entity, author: bob.diaspora_id, parent_guid: parent.guid, parent: parent_entity)
-      )
+      FactoryGirl.attributes_for(
+        :message_entity,
+        author:      bob.diaspora_id,
+        parent_guid: parent.guid,
+        parent:      parent_entity
+      ).tap {|hash| add_signatures(hash, Entities::Message) }
     }
     let(:data) {
       FactoryGirl.attributes_for(:conversation_entity).merge!(

--- a/spec/lib/diaspora_federation/entities/like_spec.rb
+++ b/spec/lib/diaspora_federation/entities/like_spec.rb
@@ -3,15 +3,13 @@ module DiasporaFederation
     let(:parent) { FactoryGirl.create(:post, author: bob) }
     let(:parent_entity) { FactoryGirl.build(:related_entity, author: bob.diaspora_id) }
     let(:data) {
-      add_signatures(
-        FactoryGirl.build(
-          :like_entity,
-          author:      alice.diaspora_id,
-          parent_guid: parent.guid,
-          parent_type: parent.entity_type,
-          parent:      parent_entity
-        )
-      )
+      FactoryGirl.attributes_for(
+        :like_entity,
+        author:      alice.diaspora_id,
+        parent_guid: parent.guid,
+        parent_type: parent.entity_type,
+        parent:      parent_entity
+      ).tap {|hash| add_signatures(hash) }
     }
 
     let(:xml) { <<-XML }

--- a/spec/lib/diaspora_federation/entities/message_spec.rb
+++ b/spec/lib/diaspora_federation/entities/message_spec.rb
@@ -3,9 +3,9 @@ module DiasporaFederation
     let(:parent) { FactoryGirl.create(:conversation, author: bob) }
     let(:parent_entity) { FactoryGirl.build(:related_entity, author: bob.diaspora_id) }
     let(:data) {
-      add_signatures(
-        FactoryGirl.build(:message_entity, author: alice.diaspora_id, parent_guid: parent.guid, parent: parent_entity)
-      )
+      FactoryGirl
+        .attributes_for(:message_entity, author: alice.diaspora_id, parent_guid: parent.guid, parent: parent_entity)
+        .tap {|hash| add_signatures(hash) }
     }
 
     let(:xml) { <<-XML }

--- a/spec/lib/diaspora_federation/entities/participation_spec.rb
+++ b/spec/lib/diaspora_federation/entities/participation_spec.rb
@@ -3,15 +3,13 @@ module DiasporaFederation
     let(:parent) { FactoryGirl.create(:post, author: bob) }
     let(:parent_entity) { FactoryGirl.build(:related_entity, author: bob.diaspora_id) }
     let(:data) {
-      add_signatures(
-        FactoryGirl.build(
-          :participation_entity,
-          author:      alice.diaspora_id,
-          parent_guid: parent.guid,
-          parent_type: parent.entity_type,
-          parent:      parent_entity
-        )
-      )
+      FactoryGirl.attributes_for(
+        :participation_entity,
+        author:      alice.diaspora_id,
+        parent_guid: parent.guid,
+        parent_type: parent.entity_type,
+        parent:      parent_entity
+      ).tap {|hash| add_signatures(hash) }
     }
 
     let(:xml) { <<-XML }

--- a/spec/lib/diaspora_federation/entities/poll_participation_spec.rb
+++ b/spec/lib/diaspora_federation/entities/poll_participation_spec.rb
@@ -3,14 +3,12 @@ module DiasporaFederation
     let(:parent) { FactoryGirl.create(:poll, author: bob) }
     let(:parent_entity) { FactoryGirl.build(:related_entity, author: bob.diaspora_id) }
     let(:data) {
-      add_signatures(
-        FactoryGirl.build(
-          :poll_participation_entity,
-          author:      alice.diaspora_id,
-          parent_guid: parent.guid,
-          parent:      parent_entity
-        )
-      )
+      FactoryGirl.attributes_for(
+        :poll_participation_entity,
+        author:      alice.diaspora_id,
+        parent_guid: parent.guid,
+        parent:      parent_entity
+      ).tap {|hash| add_signatures(hash) }
     }
 
     let(:xml) { <<-XML }

--- a/spec/lib/diaspora_federation/entities/relayable_retraction_spec.rb
+++ b/spec/lib/diaspora_federation/entities/relayable_retraction_spec.rb
@@ -16,7 +16,7 @@ module DiasporaFederation
         target_type: target.entity_type,
         target:      target_entity
       ).send(:enriched_properties).tap do |data|
-        data[:target_author_signature] = nil
+        data[:target_author_signature] = ""
         data[:target] = target_entity
       end
     }

--- a/spec/lib/diaspora_federation/entity_spec.rb
+++ b/spec/lib/diaspora_federation/entity_spec.rb
@@ -68,7 +68,7 @@ module DiasporaFederation
     describe "#to_h" do
       it "returns a hash of the internal data" do
         entity = Entities::TestDefaultEntity.new(data)
-        expect(entity.to_h).to eq(data)
+        expect(entity.to_h).to eq(data.transform_values(&:to_s))
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,12 +38,10 @@ def expect_callback(*opts)
   expect(DiasporaFederation.callbacks).to receive(:trigger).with(*opts)
 end
 
-def add_signatures(entity)
-  properties = entity.send(:enriched_properties)
-  entity.to_h.tap do |hash|
-    hash[:author_signature] = properties[:author_signature]
-    hash[:parent_author_signature] = properties[:parent_author_signature]
-  end
+def add_signatures(hash, klass=described_class)
+  properties = klass.new(hash).send(:enriched_properties)
+  hash[:author_signature] = properties[:author_signature]
+  hash[:parent_author_signature] = properties[:parent_author_signature]
 end
 
 # Requires supporting files with custom matchers and macros, etc,

--- a/spec/support/shared_entity_specs.rb
+++ b/spec/support/shared_entity_specs.rb
@@ -26,15 +26,19 @@ shared_examples "an Entity subclass" do
 
     describe "#to_h" do
       it "should return a hash with nested data" do
-        expected_data = data.map {|key, value|
-          if [String, TrueClass, FalseClass, Integer, Time, NilClass].any? {|c| value.is_a? c }
-            [key, value]
+        expected_data = data.transform_values {|value|
+          if [String, TrueClass, FalseClass, Integer].any? {|c| value.is_a? c }
+            value.to_s
+          elsif value.nil?
+            nil
+          elsif value.is_a? Time
+            value.iso8601
           elsif value.instance_of?(Array)
-            [key, value.map(&:to_h)]
+            value.map(&:to_h)
           else
-            [key, value.to_h]
+            value.to_h
           end
-        }.to_h
+        }
 
         expect(instance.to_h).to eq(expected_data)
       end


### PR DESCRIPTION
By the results of the discussion at #42, there are changes to the `to_h` method.

Since `to_h` is intensively used for data generation for entity initializers in the `diaspora_federation` test suite, a move from `properties` to `enriched_properties` requires to uptade entity construction routine to support initialization of properties (boolean, integer, time) with string values.