### PR TITLE
Fix CI script false positive return code

### DIFF
--- a/test/scripts/travis.sh
+++ b/test/scripts/travis.sh
@@ -9,5 +9,7 @@ if [[ ${TRAVIS_RUBY_VERSION} == "2.1" ]]; then
 else
   # ruby >= 2.2
   bundle exec rake --trace
+  test_exit_code=$?
   bundle exec codeclimate-test-reporter
+  exit $test_exit_code
 fi


### PR DESCRIPTION
For Ruby >= 2.2 travis.sh returned 0 even when the rspec test suite
has failed. This commit passes the return value from the test suite
as the CI script return value.