### PR TITLE
Don't use versioning in JSON schema id

### DIFF
--- a/lib/diaspora_federation/schemas/federation_entities.json
+++ b/lib/diaspora_federation/schemas/federation_entities.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://diaspora.github.io/diaspora_federation/schemas/federation_entities-0.2.0-dev.json",
+  "id": "https://diaspora.github.io/diaspora_federation/schemas/federation_entities.json",
   "oneOf": [
     {"$ref": "#/definitions/comment"},
     {"$ref": "#/definitions/like"},


### PR DESCRIPTION
While there are some schemas ([1](http://json.schemastore.org/ninjs), [2](http://json.schemastore.org/xunit.runner.schema)) which do that, I found it rather problematic to work with versioned id when referring it from another schema.

JSON schema specification says that you're not actually expected to download schema from the URL when you want to refer it from other schema. It is more likely that you provide the schema out-of-band.

In Ruby with the gems we use it is possible to achive this using `JSON::Validator.add_schema` method call. It registers a schema and if the `Validator` then meets this schema referenced in another one, it uses the schema provided earlier.

While JSON schema specification says that a schema can be referenced with more than one ID, `JSON::Validator` actually uses the one provided inside the schema if there is one. There is no way I can tell it to reference this schema as `https://diaspora.github.io/diaspora_federation/schemas/federation_entities.json` if it has `https://diaspora.github.io/diaspora_federation/schemas/federation_entities-whatever.json` inside. While it may be specificity of the implementation, it doesn't allow me to reference schema without version in another schema in the diaspora project. Referencing schema with the version number doesn't feel okay, since we likely don't want to change the version number everywhere it referenced on version bump. That's why I don't think we should use this versioning method.

We can still use version numbers in published schema files. We could also add `"version"` property to the schema root object. However these are not conventional ways to maintain versioning of JSON schemas and there is no such thing. I'm not sure what practice we should take and if we need any explicit versioning at all.

For instance, [nodeinfo](https://github.com/jhass/nodeinfo/blob/master/schemas/1.1/schema.json) uses versioning in the ID. Maybe @jhass can help us here to decide? But nodeinfo schemas are used directly and not used as a reference inside other JSON schemas. Using this approach would mean for us either referencing the schema with the version everywhere where it is used or making hacky workarounds to use non-versioned ids (like zeroing `json_schema["id"]` value before injecting the schema to validator).