### PR TITLE
Add public flag to profile entity

### DIFF
--- a/docs/_entities/profile.md
+++ b/docs/_entities/profile.md
@@ -24,6 +24,7 @@ This entity contains all the profile data of a person.
 | `bio`              | [Markdown][markdown] (65535) | The description of the person. This field can contain markdown.                                          |
 | `location`         | [String][string] (255)       | The location of the person.                                                                              |
 | `searchable`       | [Boolean][boolean]           | `false` if the person doesn't want to be searchable by name.                                             |
+| `public`           | [Boolean][boolean]           | `true` if the profile is visible to everyone.                                                            |
 | `nsfw`             | [Boolean][boolean]           | `true` if all posts of this person should be marked as NSFW.                                             |
 | `tag_string`       | [String][string]             | A list of hashtags for this person, each tag beginning with `#` and seperated by spaces, at most 5 tags. |
 
@@ -42,6 +43,7 @@ This entity contains all the profile data of a person.
   <bio>some text about me</bio>
   <location>github</location>
   <searchable>true</searchable>
+  <public>false</public>
   <nsfw>false</nsfw>
   <tag_string>#i #love #tags</tag_string>
 </profile>

--- a/lib/diaspora_federation/entities/profile.rb
+++ b/lib/diaspora_federation/entities/profile.rb
@@ -53,6 +53,11 @@ module DiasporaFederation
       #   @return [Boolean] searchable flag
       property :searchable, :boolean, default: true
 
+      # @!attribute [r] public
+      #   Shows whether the profile is visible to everyone or only to contacts
+      #   @return [Boolean] is it public
+      property :public, :boolean, default: false
+
       property :nsfw, :boolean, default: false
       property :tag_string, :string, default: nil
 

--- a/lib/diaspora_federation/test/factories.rb
+++ b/lib/diaspora_federation/test/factories.rb
@@ -66,6 +66,7 @@ module DiasporaFederation
         bio "some text about me"
         location "github"
         searchable true
+        public false
         nsfw false
         tag_string "#i #love #tags"
       end

--- a/lib/diaspora_federation/validators/profile_validator.rb
+++ b/lib/diaspora_federation/validators/profile_validator.rb
@@ -23,7 +23,7 @@ module DiasporaFederation
       rule :location, length: {maximum: 255}
 
       rule :searchable, :boolean
-
+      rule :public, :boolean
       rule :nsfw, :boolean
 
       rule :tag_string, tag_count: {maximum: 5}

--- a/spec/lib/diaspora_federation/entities/account_migration_spec.rb
+++ b/spec/lib/diaspora_federation/entities/account_migration_spec.rb
@@ -30,6 +30,7 @@ module DiasporaFederation
     <bio>#{data[:profile].bio}</bio>
     <location>#{data[:profile].location}</location>
     <searchable>#{data[:profile].searchable}</searchable>
+    <public>#{data[:profile].public}</public>
     <nsfw>#{data[:profile].nsfw}</nsfw>
     <tag_string>#{data[:profile].tag_string}</tag_string>
   </profile>

--- a/spec/lib/diaspora_federation/entities/person_spec.rb
+++ b/spec/lib/diaspora_federation/entities/person_spec.rb
@@ -19,6 +19,7 @@ module DiasporaFederation
     <bio>#{data[:profile].bio}</bio>
     <location>#{data[:profile].location}</location>
     <searchable>#{data[:profile].searchable}</searchable>
+    <public>#{data[:profile].public}</public>
     <nsfw>#{data[:profile].nsfw}</nsfw>
     <tag_string>#{data[:profile].tag_string}</tag_string>
   </profile>

--- a/spec/lib/diaspora_federation/entities/profile_spec.rb
+++ b/spec/lib/diaspora_federation/entities/profile_spec.rb
@@ -15,6 +15,7 @@ module DiasporaFederation
   <bio>#{data[:bio]}</bio>
   <location>#{data[:location]}</location>
   <searchable>#{data[:searchable]}</searchable>
+  <public>#{data[:public]}</public>
   <nsfw>#{data[:nsfw]}</nsfw>
   <tag_string>#{data[:tag_string]}</tag_string>
 </profile>
@@ -35,6 +36,7 @@ XML
     "bio": "#{data[:bio]}",
     "location": "#{data[:location]}",
     "searchable": #{data[:searchable]},
+    "public": #{data[:public]},
     "nsfw": #{data[:nsfw]},
     "tag_string": "#{data[:tag_string]}"
   }
@@ -68,6 +70,7 @@ XML
         expect(parsed_instance.bio).to be_nil
         expect(parsed_instance.location).to be_nil
         expect(parsed_instance.searchable).to be_truthy
+        expect(parsed_instance.public).to be_falsey
         expect(parsed_instance.nsfw).to be_falsey
         expect(parsed_instance.tag_string).to be_nil
       end

--- a/spec/lib/diaspora_federation/federation/receiver/public_spec.rb
+++ b/spec/lib/diaspora_federation/federation/receiver/public_spec.rb
@@ -126,10 +126,10 @@ module DiasporaFederation
         end
 
         it "allows entities without public flag" do
-          profile = Fabricate(:profile_entity)
-          magic_env = Salmon::MagicEnvelope.new(profile, profile.author)
+          like = Fabricate(:like_entity)
+          magic_env = Salmon::MagicEnvelope.new(like, like.author)
 
-          expect_callback(:receive_entity, profile, profile.author, nil)
+          expect_callback(:receive_entity, like, like.author, nil)
 
           described_class.new(magic_env).receive
         end

--- a/spec/lib/diaspora_federation/validators/profile_validator_spec.rb
+++ b/spec/lib/diaspora_federation/validators/profile_validator_spec.rb
@@ -61,7 +61,7 @@ module DiasporaFederation
       end
     end
 
-    %i(searchable nsfw).each do |prop|
+    %i(searchable public nsfw).each do |prop|
       describe "##{prop}" do
         it_behaves_like "a boolean validator" do
           let(:property) { prop }


### PR DESCRIPTION
Diaspora has this flag for some time now, but it is pod-local only. With this change we can also federate this information. We can also federate public profiles publicly, so public profiles with many contacts need to be federated only once (would be useful for the diaspora\* HQ account for example).