### PR TITLE
Improve WebFinger generation

### DIFF
--- a/lib/diaspora_federation/discovery/web_finger.rb
+++ b/lib/diaspora_federation/discovery/web_finger.rb
@@ -38,7 +38,7 @@ module DiasporaFederation
       # @!attribute [r] alias_url
       #   @note could be nil
       #   @return [String] link to the users profile
-      property :alias_url, :string
+      property :alias_url, :string, default: nil
 
       # @!attribute [r] hcard_url
       #   @return [String] link to the +hCard+
@@ -50,7 +50,7 @@ module DiasporaFederation
 
       # @!attribute [r] profile_url
       #   @return [String] link to the users profile
-      property :profile_url, :string
+      property :profile_url, :string, default: nil
 
       # @!attribute [r] atom_url
       #   This atom feed is an Activity Stream of the user's public posts. diaspora*
@@ -61,18 +61,18 @@ module DiasporaFederation
       #   Note that this feed MAY also be made available through the PubSubHubbub
       #   mechanism by supplying a <link rel="hub"> in the atom feed itself.
       #   @return [String] atom feed url
-      property :atom_url, :string
+      property :atom_url, :string, default: nil
 
       # @!attribute [r] salmon_url
       #   @note could be nil
       #   @return [String] salmon endpoint url
       #   @see https://cdn.rawgit.com/salmon-protocol/salmon-protocol/master/draft-panzer-salmon-00.html#SMLR
       #     Panzer draft for Salmon, paragraph 3.3
-      property :salmon_url, :string
+      property :salmon_url, :string, default: nil
 
       # @!attribute [r] subscribe_url
       #   This url is used to find another user on the home-pod of the user in the webfinger.
-      property :subscribe_url, :string
+      property :subscribe_url, :string, default: nil
 
       # +hcard_url+ link relation
       REL_HCARD = "http://microformats.org/profile/hcard".freeze
@@ -97,8 +97,8 @@ module DiasporaFederation
       # @return [String] XML string
       def to_xml
         doc = XrdDocument.new
-        doc.subject = @acct_uri
-        doc.aliases << @alias_url
+        doc.subject = acct_uri
+        doc.aliases << alias_url
 
         add_links_to(doc)
 
@@ -147,14 +147,18 @@ module DiasporaFederation
       end
 
       def add_links_to(doc)
-        doc.links << {rel: REL_HCARD, type: "text/html", href: @hcard_url}
-        doc.links << {rel: REL_SEED, type: "text/html", href: @seed_url}
+        doc.links << {rel: REL_HCARD, type: "text/html", href: hcard_url}
+        doc.links << {rel: REL_SEED, type: "text/html", href: seed_url}
 
-        doc.links << {rel: REL_PROFILE, type: "text/html", href: @profile_url}
-        doc.links << {rel: REL_ATOM, type: "application/atom+xml", href: @atom_url}
-        doc.links << {rel: REL_SALMON, href: @salmon_url}
+        add_optional_links_to(doc)
+      end
 
-        doc.links << {rel: REL_SUBSCRIBE, template: @subscribe_url}
+      def add_optional_links_to(doc)
+        doc.links << {rel: REL_PROFILE, type: "text/html", href: profile_url} if profile_url
+        doc.links << {rel: REL_ATOM, type: "application/atom+xml", href: atom_url} if atom_url
+        doc.links << {rel: REL_SALMON, href: salmon_url} if salmon_url
+
+        doc.links << {rel: REL_SUBSCRIBE, template: subscribe_url} if subscribe_url
       end
 
       private_class_method def self.find_link(links, rel)

--- a/lib/diaspora_federation/discovery/web_finger.rb
+++ b/lib/diaspora_federation/discovery/web_finger.rb
@@ -9,7 +9,6 @@ module DiasporaFederation
     # @example Creating a WebFinger document from a person hash
     #   wf = WebFinger.new(
     #     acct_uri:    "acct:user@server.example",
-    #     alias_url:   "https://server.example/people/0123456789abcdef",
     #     hcard_url:   "https://server.example/hcard/users/user",
     #     seed_url:    "https://server.example/",
     #     profile_url: "https://server.example/u/user",
@@ -34,11 +33,6 @@ module DiasporaFederation
       #   for. If it does not, then this webfinger profile MUST be ignored.
       #   @return [String]
       property :acct_uri, :string
-
-      # @!attribute [r] alias_url
-      #   @note could be nil
-      #   @return [String] link to the users profile
-      property :alias_url, :string, default: nil
 
       # @!attribute [r] hcard_url
       #   @return [String] link to the +hCard+
@@ -93,12 +87,31 @@ module DiasporaFederation
       # +subscribe_url+ link relation
       REL_SUBSCRIBE = "http://ostatus.org/schema/1.0/subscribe".freeze
 
+      # Additional WebFinger data
+      # @return [Hash] additional elements
+      attr_reader :additional_data
+
+      # Initializes a new WebFinger Entity
+      #
+      # @param [Hash] data WebFinger data
+      # @param [Hash] additional_data additional WebFinger data
+      # @option additional_data [Array<String>] :aliases additional aliases
+      # @option additional_data [Hash] :properties properties
+      # @option additional_data [Array<Hash>] :links additional link elements
+      # @see DiasporaFederation::Entity#initialize
+      def initialize(data, additional_data={})
+        @additional_data = additional_data
+        super(data)
+      end
+
       # Creates the XML string from the current WebFinger instance
       # @return [String] XML string
       def to_xml
         doc = XrdDocument.new
+
         doc.subject = acct_uri
-        doc.aliases << alias_url
+        doc.aliases.concat(additional_data[:aliases]) if additional_data[:aliases]
+        doc.properties.merge!(additional_data[:properties]) if additional_data[:properties]
 
         add_links_to(doc)
 
@@ -116,7 +129,7 @@ module DiasporaFederation
 
         new(
           acct_uri:      data[:subject],
-          alias_url:     parse_alias(data[:aliases]),
+
           hcard_url:     parse_link(links, REL_HCARD),
           seed_url:      parse_link(links, REL_SEED),
           profile_url:   parse_link(links, REL_PROFILE),
@@ -151,6 +164,8 @@ module DiasporaFederation
         doc.links << {rel: REL_SEED, type: "text/html", href: seed_url}
 
         add_optional_links_to(doc)
+
+        doc.links.concat(additional_data[:links]) if additional_data[:links]
       end
 
       def add_optional_links_to(doc)
@@ -173,15 +188,6 @@ module DiasporaFederation
       private_class_method def self.parse_link_template(links, rel)
         element = find_link(links, rel)
         element ? element[:template] : nil
-      end
-
-      # This method is used to parse the alias_url from the XML.
-      # * redmatrix has sometimes no alias, return nil
-      # * old pods had quotes around the alias url, this can be removed later
-      # * friendica has two aliases and the first is with "acct:": return only an URL starting with http (or https)
-      private_class_method def self.parse_alias(aliases)
-        return nil unless aliases
-        aliases.find {|a| a.start_with?("http") }
       end
     end
   end

--- a/lib/diaspora_federation/validators/web_finger_validator.rb
+++ b/lib/diaspora_federation/validators/web_finger_validator.rb
@@ -9,7 +9,6 @@ module DiasporaFederation
 
       rule :acct_uri, :not_empty
 
-      rule :alias_url, URI: %i(host path)
       rule :hcard_url, [:not_nil, URI: %i(host path)]
       rule :seed_url, %i(not_nil URI)
       rule :profile_url, URI: %i(host path)

--- a/spec/lib/diaspora_federation/discovery/web_finger_spec.rb
+++ b/spec/lib/diaspora_federation/discovery/web_finger_spec.rb
@@ -31,6 +31,15 @@ module DiasporaFederation
 </XRD>
 XML
 
+    let(:minimal_xml) { <<-XML }
+<?xml version="1.0" encoding="UTF-8"?>
+<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+  <Subject>#{acct}</Subject>
+  <Link rel="http://microformats.org/profile/hcard" type="text/html" href="#{person.hcard_url}"/>
+  <Link rel="http://joindiaspora.com/seed_location" type="text/html" href="#{person.url}"/>
+</XRD>
+XML
+
     let(:string) { "WebFinger:#{data[:acct_uri]}" }
 
     it_behaves_like "an Entity subclass"
@@ -39,6 +48,15 @@ XML
       it "creates a nice XML document" do
         wf = Discovery::WebFinger.new(data)
         expect(wf.to_xml).to eq(xml)
+      end
+
+      it "creates minimal XML document" do
+        wf = Discovery::WebFinger.new(
+          acct_uri:  "acct:#{person.diaspora_id}",
+          hcard_url: person.hcard_url,
+          seed_url:  person.url
+        )
+        expect(wf.to_xml).to eq(minimal_xml)
       end
     end
 
@@ -56,14 +74,6 @@ XML
       end
 
       it "reads minimal xml" do
-        minimal_xml = <<-XML
-<?xml version="1.0" encoding="UTF-8"?>
-<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
-  <Subject>#{acct}</Subject>
-  <Link rel="http://microformats.org/profile/hcard" type="text/html" href="#{person.hcard_url}"/>
-  <Link rel="http://joindiaspora.com/seed_location" type="text/html" href="#{person.url}"/>
-</XRD>
-XML
         wf = Discovery::WebFinger.from_xml(minimal_xml)
         expect(wf.acct_uri).to eq(acct)
         expect(wf.hcard_url).to eq(person.hcard_url)

--- a/spec/lib/diaspora_federation/validators/web_finger_validator_spec.rb
+++ b/spec/lib/diaspora_federation/validators/web_finger_validator_spec.rb
@@ -23,7 +23,7 @@ module DiasporaFederation
     end
 
     # optional urls
-    %i(alias_url salmon_url profile_url atom_url).each do |prop|
+    %i(salmon_url profile_url atom_url).each do |prop|
       describe "##{prop}" do
         it_behaves_like "a property with a value validation/restriction" do
           let(:property) { prop }


### PR DESCRIPTION
This makes the WebFinger generation more flexible, so it's better usable for other projects.

* It makes not needed properties optional for generation (was already optional for parsing).
* It allows to add additional elements (unrelated to the diaspora protocol).
  Diaspora also needs this for OpenIDConnect when we switch to RFC7033 WebFinger (which will be the next step).