### PR TITLE
Add created_at to comment

### DIFF
--- a/lib/diaspora_federation/entities/comment.rb
+++ b/lib/diaspora_federation/entities/comment.rb
@@ -17,12 +17,6 @@ module DiasporaFederation
       #   Comment entity creation time
       #   @return [Time] creation time
       property :created_at, :timestamp, default: -> { Time.now.utc }
-
-      # Remove "created_at" when no order was received.
-      # @deprecated TODO: Remove this, this will break compatibility with pods older than 0.6.3.0.
-      def signature_order
-        @signature_order || super.tap {|order| order.delete(:created_at) }
-      end
     end
   end
 end

--- a/spec/lib/diaspora_federation/entities/comment_spec.rb
+++ b/spec/lib/diaspora_federation/entities/comment_spec.rb
@@ -19,6 +19,7 @@ module DiasporaFederation
   <guid>#{data[:guid]}</guid>
   <parent_guid>#{parent.guid}</parent_guid>
   <text>#{data[:text]}</text>
+  <created_at>#{data[:created_at].utc.iso8601}</created_at>
   <author_signature>#{data[:author_signature]}</author_signature>
   <parent_author_signature>#{data[:parent_author_signature]}</parent_author_signature>
 </comment>
@@ -39,7 +40,8 @@ XML
     "author",
     "guid",
     "parent_guid",
-    "text"
+    "text",
+    "created_at"
   ]
 }
 JSON
@@ -55,23 +57,5 @@ JSON
     it_behaves_like "a relayable Entity"
 
     it_behaves_like "a relayable JSON entity"
-
-    describe "#created_at" do
-      it "has a created_at after parse" do
-        entity = described_class.from_xml(Nokogiri::XML(xml).root)
-        expect(entity.created_at).to be_within(1).of(Time.now.utc)
-      end
-
-      it "parses the created_at from the xml if it is included and correctly signed" do
-        created_at = change_time(Time.now.utc) - 60
-        comment_data = Fabricate.attributes_for(:comment_entity, author: alice.diaspora_id, parent_guid: parent.guid)
-        comment_data[:created_at] = created_at
-        comment_data[:parent] = parent_entity
-        comment = described_class.new(comment_data, %i(author guid parent_guid text created_at))
-
-        parsed_comment = described_class.from_xml(comment.to_xml)
-        expect(parsed_comment.created_at).to eq(created_at)
-      end
-    end
   end
 end

--- a/spec/support/shared_entity_specs.rb
+++ b/spec/support/shared_entity_specs.rb
@@ -107,8 +107,8 @@ shared_examples "a relayable Entity" do
     end
 
     it "computes correct signatures for the entity" do
-      order = described_class.class_props.keys - %i(author_signature parent_author_signature parent created_at)
-      signed_string = order.map {|name| data[name] }.join(";")
+      order = described_class.class_props.keys - %i(author_signature parent_author_signature parent)
+      signed_string = order.map {|name| data[name].is_a?(Time) ? data[name].iso8601 : data[name] }.join(";")
 
       xml = instance.to_xml
 


### PR DESCRIPTION
Since my [post on diaspora](https://nerdpol.ch/posts/635fb840f46f0134b8f952540061b601) some more podmins updated, so I think we can think about this again. I use the numbers from [the-federation.info](https://the-federation.info/diaspora), but subtracted the duplicates (librenet and datataffel).

We have currently 14970 active users last month and 14599 are on a pod with 0.6.3.0 or newer. That are 97.5%. That are 4% more than 2 Months ago. Until diaspora/diaspora#7436 gets merged to `develop` it'll still take some weeks (since we are still waiting for a friendica release and then + 2-3 weeks), so maybe even more podmins updates until then. (we can create another post or ask some podmins)

So 97.5% is OK for me, I don't think we need to wait longer. Any vetos? @denschub @svbergerem @cmrd-senya @Flaburgan 

(I don't think we need a bigger discussion/vote for this, but if anybody thinks we need it, just say it. But since we need this PR anyway sooner or later, I just created it :) )

This fixes diaspora/diaspora#4269