### PR TITLE
Improve error handling for discovery errors

### DIFF
--- a/lib/diaspora_federation/discovery/discovery.rb
+++ b/lib/diaspora_federation/discovery/discovery.rb
@@ -15,6 +15,7 @@ module DiasporaFederation
 
       # Fetches all metadata for the account and saves it via callback
       # @return [Person]
+      # @raise [DiscoveryError] if something with the discovery failed
       def fetch_and_save
         logger.info "Fetch data for #{diaspora_id}"
 
@@ -23,6 +24,10 @@ module DiasporaFederation
         DiasporaFederation.callbacks.trigger(:save_person_after_webfinger, person)
         logger.info "successfully webfingered #{diaspora_id}"
         person
+      rescue DiscoveryError
+        raise # simply re-raise DiscoveryError
+      rescue => e
+        raise DiscoveryError, "Failed discovery for #{diaspora_id}: #{e.class}: #{e.message}"
       end
 
       private

--- a/lib/diaspora_federation/discovery/exceptions.rb
+++ b/lib/diaspora_federation/discovery/exceptions.rb
@@ -1,7 +1,11 @@
 module DiasporaFederation
   module Discovery
+    # Raised, if there is an error while discover a new person
+    class DiscoveryError < RuntimeError
+    end
+
     # Raised, if the XML structure is invalid
-    class InvalidDocument < RuntimeError
+    class InvalidDocument < DiscoveryError
     end
 
     # Raised, if something is wrong with the webfinger data
@@ -9,11 +13,7 @@ module DiasporaFederation
     # * if the +webfinger_url+ is missing or malformed in {HostMeta.from_base_url} or {HostMeta.from_xml}
     # * if the parsed XML from {WebFinger.from_xml} is incomplete
     # * if the html passed to {HCard.from_html} in some way is malformed, invalid or incomplete.
-    class InvalidData < RuntimeError
-    end
-
-    # Raised, if there is an error while discover a new person
-    class DiscoveryError < RuntimeError
+    class InvalidData < DiscoveryError
     end
   end
 end

--- a/spec/lib/diaspora_federation/discovery/discovery_spec.rb
+++ b/spec/lib/diaspora_federation/discovery/discovery_spec.rb
@@ -144,6 +144,41 @@ module DiasporaFederation
 
         expect { Discovery::Discovery.new(account).fetch_and_save }.to raise_error Discovery::DiscoveryError
       end
+
+      context "error handling" do
+        subject { Discovery::Discovery.new(account) }
+
+        it "re-raises DiscoveryError" do
+          expect(subject).to receive(:validate_diaspora_id)
+            .and_raise(Discovery::DiscoveryError, "Something went wrong!")
+
+          expect { subject.fetch_and_save }.to raise_error Discovery::DiscoveryError, "Something went wrong!"
+        end
+
+        it "re-raises InvalidDocument" do
+          expect(subject).to receive(:validate_diaspora_id)
+            .and_raise(Discovery::InvalidDocument, "Wrong document!")
+
+          expect { subject.fetch_and_save }.to raise_error Discovery::InvalidDocument, "Wrong document!"
+        end
+
+        it "re-raises InvalidData" do
+          expect(subject).to receive(:validate_diaspora_id)
+            .and_raise(Discovery::InvalidData, "Wrong data!")
+
+          expect { subject.fetch_and_save }.to raise_error Discovery::InvalidData, "Wrong data!"
+        end
+
+        it "raises a DiscoveryError when an unhandled error occurs" do
+          expect(subject).to receive(:validate_diaspora_id)
+            .and_raise("OMG! EVERYTHING IS BROKEN!")
+
+          expect {
+            subject.fetch_and_save
+          }.to raise_error Discovery::DiscoveryError,
+                           "Failed discovery for #{account}: RuntimeError: OMG! EVERYTHING IS BROKEN!"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Always raise a `DiscoveryError` when something with the discovery fails