### PR TITLE
Add blocking flag to contact message

### DIFF
--- a/docs/_entities/contact.md
+++ b/docs/_entities/contact.md
@@ -4,6 +4,8 @@ title: Contact
 
 This entity represents a contact state with another person.
 
+When `blocking` is `true`, `following` and `sharing` need to be `false` (and the other way around).
+
 ## Properties
 
 | Property    | Type                         | Description                                         |
@@ -13,6 +15,12 @@ This entity represents a contact state with another person.
 | `following` | [Boolean][boolean]           | `true` if the author is following the recipient.    |
 | `sharing`   | [Boolean][boolean]           | `true` if the author is sharing with the recipient. |
 
+## Optional Properties
+
+| Property   | Type               | Description                                     |
+| ---------- | ------------------ | ----------------------------------------------- |
+| `blocking` | [Boolean][boolean] | `true` if the author is blocking the recipient. |
+
 ## Example
 
 ~~~xml
@@ -21,6 +29,7 @@ This entity represents a contact state with another person.
   <recipient>bob@example.com</recipient>
   <following>true</following>
   <sharing>true</sharing>
+  <blocking>false</blocking>
 </contact>
 ~~~
 

--- a/lib/diaspora_federation/entities/contact.rb
+++ b/lib/diaspora_federation/entities/contact.rb
@@ -25,9 +25,24 @@ module DiasporaFederation
       #   @return [Boolean] if the author is sharing with the person
       property :sharing, :boolean, default: true
 
+      # @!attribute [r] blocking
+      #   @return [Boolean] if the author is blocking the person
+      property :blocking, :boolean, optional: true, default: false
+
       # @return [String] string representation of this object
       def to_s
         "Contact:#{author}:#{recipient}"
+      end
+
+      private
+
+      def validate
+        super
+
+        return unless (following || sharing) && blocking
+
+        raise ValidationError,
+              "flags invalid: following:#{following}/sharing:#{sharing} and blocking:#{blocking} can't both be true"
       end
     end
   end

--- a/lib/diaspora_federation/test/factories.rb
+++ b/lib/diaspora_federation/test/factories.rb
@@ -113,6 +113,7 @@ module DiasporaFederation
         recipient { Fabricate.sequence(:diaspora_id) }
         following true
         sharing true
+        blocking false
       end
 
       Fabricator(:comment_entity, class_name: DiasporaFederation::Entities::Comment, from: :relayable_entity) do

--- a/lib/diaspora_federation/validators/contact_validator.rb
+++ b/lib/diaspora_federation/validators/contact_validator.rb
@@ -8,6 +8,7 @@ module DiasporaFederation
       rule :recipient, %i[not_empty diaspora_id]
       rule :following, :boolean
       rule :sharing, :boolean
+      rule :blocking, :boolean
     end
   end
 end

--- a/spec/lib/diaspora_federation/entities/contact_spec.rb
+++ b/spec/lib/diaspora_federation/entities/contact_spec.rb
@@ -8,6 +8,7 @@ module DiasporaFederation
   <recipient>#{data[:recipient]}</recipient>
   <following>#{data[:following]}</following>
   <sharing>#{data[:sharing]}</sharing>
+  <blocking>#{data[:blocking]}</blocking>
 </contact>
 XML
 
@@ -16,5 +17,35 @@ XML
     it_behaves_like "an Entity subclass"
 
     it_behaves_like "an XML Entity"
+
+    describe "#validate" do
+      it "allows 'following' and 'sharing' to be true" do
+        combinations = [
+          {following: true, sharing: true, blocking: false},
+          {following: true, sharing: false, blocking: false},
+          {following: false, sharing: true, blocking: false}
+        ]
+        combinations.each do |combination|
+          expect { Entities::Contact.new(data.merge(combination)) }.not_to raise_error
+        end
+      end
+
+      it "allows 'blocking' to be true" do
+        expect {
+          Entities::Contact.new(data.merge(following: false, sharing: false, blocking: true))
+        }.not_to raise_error
+      end
+
+      it "doesn't allow 'following'/'sharing' and 'blocking' to be true" do
+        combinations = [
+          {following: true, sharing: true, blocking: true},
+          {following: true, sharing: false, blocking: true},
+          {following: false, sharing: true, blocking: true}
+        ]
+        combinations.each do |combination|
+          expect { Entities::Contact.new(data.merge(combination)) }.to raise_error Entity::ValidationError
+        end
+      end
+    end
   end
 end

--- a/spec/lib/diaspora_federation/validators/contact_validator_spec.rb
+++ b/spec/lib/diaspora_federation/validators/contact_validator_spec.rb
@@ -13,7 +13,7 @@ module DiasporaFederation
       end
     end
 
-    %i[following sharing].each do |prop|
+    %i[following sharing blocking].each do |prop|
       describe "##{prop}" do
         it_behaves_like "a boolean validator" do
           let(:property) { prop }


### PR DESCRIPTION
Diaspora currently doesn't federate this information, which causes a lot of bad UX (users writing a comment which then immediately gets deleted again). But this information is not really "secret", because a user can just like a post and when the like gets deleted again, the author of the post probably ignores them (so only bad UX with no real win).

The main reason why I didn't want to have this federated was, that federation was really unstable, and we had already inconsistent sharing states, and I didn't want a user to be stuck in blocking state, when the other person already unblocked them. But federation improved a lot and works quiet stable now. That's why I think we can start federating this now.