### PR TITLE
Add text property to reshares to allow quoted reshares

### DIFF
--- a/docs/_entities/reshare.md
+++ b/docs/_entities/reshare.md
@@ -23,10 +23,11 @@ is not valid.
 
 ## Optional Properties
 
-| Property                | Type (Length)          | Description                                                                                |
-| ----------------------- | ---------------------- | ------------------------------------------------------------------------------------------ |
-| `provider_display_name` | [String][string] (255) | The means by which the author has posted the reshare.                                      |
-| `public`                | [Boolean][boolean]     | `false` if the reshare is not public (diaspora\* currenlty only supports public reshares). |
+| Property                | Type (Length)                | Description                                                                                |
+| ----------------------- | ---------------------------- | ------------------------------------------------------------------------------------------ |
+| `text`                  | [Markdown][markdown] (65535) | A comment about the reshared post.                                                         |
+| `provider_display_name` | [String][string] (255)       | The means by which the author has posted the reshare.                                      |
+| `public`                | [Boolean][boolean]           | `false` if the reshare is not public (diaspora\* currenlty only supports public reshares). |
 
 ## Example
 

--- a/lib/diaspora_federation/entities/reshare.rb
+++ b/lib/diaspora_federation/entities/reshare.rb
@@ -23,6 +23,11 @@ module DiasporaFederation
       #   @return [Boolean] public
       property :public, :boolean, optional: true, default: true # always true? (we only reshare public posts)
 
+      # @!attribute [r] text
+      #   A comment about the reshared post
+      #   @return [String] text of the comment about the reshare
+      property :text, :string, optional: true
+
       # @return [String] string representation of this object
       def to_s
         "#{super}:#{root_guid}"

--- a/lib/diaspora_federation/test/factories.rb
+++ b/lib/diaspora_federation/test/factories.rb
@@ -151,6 +151,7 @@ module DiasporaFederation
         guid { Fabricate.sequence(:guid) }
         author { Fabricate.sequence(:diaspora_id) }
         public true
+        text "this post is very cool!"
         created_at { Time.now.utc }
         provider_display_name { "the testsuite" }
       end

--- a/lib/diaspora_federation/validators/reshare_validator.rb
+++ b/lib/diaspora_federation/validators/reshare_validator.rb
@@ -13,6 +13,8 @@ module DiasporaFederation
       rule :guid, :guid
 
       rule :public, :boolean
+
+      rule :text, length: {maximum: 65_535}
     end
   end
 end

--- a/spec/lib/diaspora_federation/entities/reshare_spec.rb
+++ b/spec/lib/diaspora_federation/entities/reshare_spec.rb
@@ -12,6 +12,7 @@ module DiasporaFederation
   <root_author>#{data[:root_author]}</root_author>
   <root_guid>#{data[:root_guid]}</root_guid>
   <public>#{data[:public]}</public>
+  <text>#{data[:text]}</text>
 </reshare>
 XML
 
@@ -25,7 +26,8 @@ XML
     "provider_display_name": "#{data[:provider_display_name]}",
     "root_author": "#{data[:root_author]}",
     "root_guid": "#{data[:root_guid]}",
-    "public": #{data[:public]}
+    "public": #{data[:public]},
+    "text": "#{data[:text]}"
   }
 }
 JSON

--- a/spec/lib/diaspora_federation/validators/reshare_validator_spec.rb
+++ b/spec/lib/diaspora_federation/validators/reshare_validator_spec.rb
@@ -32,5 +32,13 @@ module DiasporaFederation
     it_behaves_like "a boolean validator" do
       let(:property) { :public }
     end
+
+    describe "#text" do
+      it_behaves_like "a property with a value validation/restriction" do
+        let(:property) { :text }
+        let(:wrong_values) { ["a" * 65_536] }
+        let(:correct_values) { ["a" * 65_535, nil, ""] }
+      end
+    end
   end
 end


### PR DESCRIPTION
With this property the author of the reshare can add his own thoughts about the post to the reshare.

@jaywink mentioned that some time ago that he wants to use this property and I thought it is a good idea to add it to add it to the official documentation.

This will also help to solve diaspora/diaspora#4219 by adding quoted reshares to diaspora as discussed [here](https://discourse.diasporafoundation.org/t/reshares/357).