### PR TITLE
Tighten the validation of diaspora* IDs

### DIFF
--- a/lib/diaspora_federation/validators/rules/diaspora_id.rb
+++ b/lib/diaspora_federation/validators/rules/diaspora_id.rb
@@ -4,6 +4,9 @@ module Validation
     #
     # A simple rule to validate the base structure of diaspora* IDs.
     class DiasporaId
+      # Maximum length of a full diaspora* ID
+      DIASPORA_ID_MAX_LENGTH = 255
+
       # The Regex for a valid diaspora* ID
       DIASPORA_ID_REGEX = begin
         username       = "[[:lower:]\\d\\-\\.\\_]+"
@@ -29,7 +32,10 @@ module Validation
 
       # Determines if value is a valid diaspora* ID
       def valid_value?(value)
-        value.is_a?(String) && value =~ DIASPORA_ID
+        return false unless value.is_a?(String)
+        return false if value.length > DIASPORA_ID_MAX_LENGTH
+
+        value =~ DIASPORA_ID
       end
 
       # This rule has no params.

--- a/lib/diaspora_federation/validators/rules/diaspora_id.rb
+++ b/lib/diaspora_federation/validators/rules/diaspora_id.rb
@@ -6,17 +6,14 @@ module Validation
     class DiasporaId
       # The Regex for a valid diaspora* ID
       DIASPORA_ID_REGEX = begin
-        letter         = "a-zA-Z"
-        digit          = "0-9"
-        hexadecimal    = "[a-fA-F#{digit}]"
-        username       = "[#{letter}#{digit}\\-\\_\\.]+"
-        hostname_part  = "[#{letter}#{digit}\\-]"
+        username       = "[[:lower:]\\d\\-\\.\\_]+"
+        hostname_part  = "[[:lower:]\\d\\-]"
         hostname       = "#{hostname_part}+(?:[.]#{hostname_part}*)*"
-        ipv4           = "(?:[#{digit}]{1,3}\\.){3}[#{digit}]{1,3}"
-        ipv6           = "\\[(?:#{hexadecimal}{0,4}:){0,7}#{hexadecimal}{1,4}\\]"
+        ipv4           = "(?:[\\d]{1,3}\\.){3}[\\d]{1,3}"
+        ipv6           = "\\[(?:[[:xdigit:]]{0,4}:){0,7}[[:xdigit:]]{1,4}\\]"
         ip_addr        = "(?:#{ipv4}|#{ipv6})"
         domain         = "(?:#{hostname}|#{ip_addr})"
-        port           = "(?::[#{digit}]+)?"
+        port           = "(?::[\\d]+)?"
 
         "#{username}\\@#{domain}#{port}"
       end

--- a/spec/lib/diaspora_federation/validators/rules/diaspora_id_spec.rb
+++ b/spec/lib/diaspora_federation/validators/rules/diaspora_id_spec.rb
@@ -83,6 +83,22 @@ describe Validation::Rule::DiasporaId do
       expect(validator.errors).to include(:diaspora_id)
     end
 
+    it "fails if the diaspora* ID contains uppercase characters in the username" do
+      validator = Validation::Validator.new(OpenStruct.new(diaspora_id: "SOME_USER@example.com"))
+      validator.rule(:diaspora_id, :diaspora_id)
+
+      expect(validator).not_to be_valid
+      expect(validator.errors).to include(:diaspora_id)
+    end
+
+    it "fails if the diaspora* ID contains uppercase characters in the domain-name" do
+      validator = Validation::Validator.new(OpenStruct.new(diaspora_id: "some_user@EXAMPLE.com"))
+      validator.rule(:diaspora_id, :diaspora_id)
+
+      expect(validator).not_to be_valid
+      expect(validator.errors).to include(:diaspora_id)
+    end
+
     it "fails for nil and empty" do
       [nil, ""].each do |val|
         validator = Validation::Validator.new(OpenStruct.new(diaspora_id: val))

--- a/spec/lib/diaspora_federation/validators/rules/diaspora_id_spec.rb
+++ b/spec/lib/diaspora_federation/validators/rules/diaspora_id_spec.rb
@@ -99,6 +99,14 @@ describe Validation::Rule::DiasporaId do
       expect(validator.errors).to include(:diaspora_id)
     end
 
+    it "fails if the diaspora* ID is longer than 255 characters" do
+      validator = Validation::Validator.new(OpenStruct.new(diaspora_id: "#{'a' * 244}@example.com"))
+      validator.rule(:diaspora_id, :diaspora_id)
+
+      expect(validator).not_to be_valid
+      expect(validator.errors).to include(:diaspora_id)
+    end
+
     it "fails for nil and empty" do
       [nil, ""].each do |val|
         validator = Validation::Validator.new(OpenStruct.new(diaspora_id: val))


### PR DESCRIPTION
In a discussion with @SuperTux88, we discovered that our validation mechanism for diaspora\* IDs is not perfect. In the documentation, there are two additional rules currently not covered by the validator:

> The diaspora* ID is at most 255 chars long and it must be lowercase.

I altered the regex so that uppercased usernames and hostnames will fail the validation. This does not change our current behavior in reality, since diaspora\* already fails when using uppercase characters.

While working on it, I replaced the `letter`, `digit`, and `hexadecimal` parts with their POSIX character class counterparts. Ultimately, this should make the final expression more readable. Because the parts are named now anyway, I removed the individual variable definitions for them.

In addition, I added a check that fails if the IDs length exceeds 255 characters.