### PR TITLE
Don't fetch the same entity twice in the same thread

### DIFF
--- a/lib/diaspora_federation/federation/fetcher.rb
+++ b/lib/diaspora_federation/federation/fetcher.rb
@@ -7,15 +7,9 @@ module DiasporaFederation
       # @param [Symbol, String] entity_type snake_case version of the entity class
       # @param [String] guid guid of the entity to fetch
       def self.fetch_public(author, entity_type, guid)
-        url = DiasporaFederation.callbacks.trigger(
-          :fetch_person_url_to, author, "/fetch/#{entity_name(entity_type)}/#{guid}"
-        )
-        response = HttpClient.get(url)
-        raise "Failed to fetch #{url}: #{response.status}" unless response.success?
-
-        magic_env_xml = Nokogiri::XML(response.body).root
-        magic_env = Salmon::MagicEnvelope.unenvelop(magic_env_xml)
-        Receiver::Public.new(magic_env).receive
+        type = entity_name(entity_type).to_s
+        raise "Already fetching ..." if fetching[type].include?(guid)
+        fetch_from_url(author, type, guid)
       rescue => e # rubocop:disable Lint/RescueWithoutErrorClass
         raise NotFetchable, "Failed to fetch #{entity_type}:#{guid} from #{author}: #{e.class}: #{e.message}"
       end
@@ -26,6 +20,23 @@ module DiasporaFederation
         raise DiasporaFederation::Entity::UnknownEntity, class_name unless Entities.const_defined?(class_name)
 
         class_name.gsub(/(.)([A-Z])/, '\1_\2').downcase
+      end
+
+      private_class_method def self.fetch_from_url(author, type, guid)
+        fetching[type] << guid
+
+        url = DiasporaFederation.callbacks.trigger(:fetch_person_url_to, author, "/fetch/#{type}/#{guid}")
+        response = HttpClient.get(url)
+        raise "Failed to fetch #{url}: #{response.status}" unless response.success?
+
+        Receiver.receive_public(response.body)
+      ensure
+        fetching[type].delete(guid)
+      end
+
+      # currently fetching entities in the same thread
+      private_class_method def self.fetching
+        Thread.current[:fetching_entities] ||= Hash.new {|h, k| h[k] = [] }
       end
 
       # Raised, if the entity is not fetchable


### PR DESCRIPTION
Normally this shouldn't happen, but it could be used as an attack vector when somebody creates this scenario manually and links to it, so pods start fetching the loop.

When two threads fetch the same entity (which can happen when receiving the same entity twice), this isn't a problem, because the receive method can handle duplicates anyway.