### PR TITLE
Fix when booleans in relayables are false

### DIFF
--- a/lib/diaspora_federation/entities/relayable.rb
+++ b/lib/diaspora_federation/entities/relayable.rb
@@ -148,7 +148,7 @@ module DiasporaFederation
           hash[:parent_author_signature] = parent_author_signature || sign_with_parent_author_if_available.to_s
         end
         order = signature_order + %i[author_signature parent_author_signature]
-        order.map {|element| [element, data[element] || ""] }.to_h
+        order.map {|element| [element, data[element].to_s] }.to_h
       end
 
       def signature_order=(order)

--- a/spec/entities.rb
+++ b/spec/entities.rb
@@ -76,6 +76,14 @@ module DiasporaFederation
 
       property :property, :string, optional: true
     end
+
+    class TestRelayableWithBoolean < DiasporaFederation::Entity
+      PARENT_TYPE = "Parent".freeze
+
+      include Entities::Relayable
+
+      property :test, :boolean
+    end
   end
 
   module Validators

--- a/spec/lib/diaspora_federation/entities/relayable_spec.rb
+++ b/spec/lib/diaspora_federation/entities/relayable_spec.rb
@@ -263,6 +263,23 @@ XML
 
         expect(xml.at_xpath("parent_author_signature").text).to eq("")
       end
+
+      it "adds 'false' booleans" do
+        expected_xml = <<-XML
+<test_relayable_with_boolean>
+  <author>#{author}</author>
+  <guid>#{guid}</guid>
+  <parent_guid>#{parent_guid}</parent_guid>
+  <test>false</test>
+  <author_signature>aa</author_signature>
+  <parent_author_signature>bb</parent_author_signature>
+</test_relayable_with_boolean>
+XML
+
+        xml = Entities::TestRelayableWithBoolean.new(hash_with_fake_signatures.merge(test: false)).to_xml
+
+        expect(xml.to_s.strip).to eq(expected_xml.strip)
+      end
     end
 
     describe ".from_xml" do


### PR DESCRIPTION
This was a problem with dislikes.

It's safe to use `to_s` here, because we have only strings, numbers and booleans here anyway, because relayables don't support nested entities. `to_s` is used to generate the `signature_data` string too.

https://github.com/diaspora/diaspora_federation/blob/7503e9a804ea2ccf27ad7edb70da42b6870a548f/lib/diaspora_federation/entities/relayable.rb#L161-L164