### PR TITLE
Editable entities

### DIFF
--- a/docs/_entities/comment.md
+++ b/docs/_entities/comment.md
@@ -9,20 +9,21 @@ See also: [Relayable][relayable]
 
 ## Properties
 
-| Property                  | Type (Length)                | Description                                     |
-| ------------------------- | ---------------------------- | ----------------------------------------------- |
-| `author`                  | [diaspora\* ID][diaspora-id] | The diaspora\* ID of the author of the comment. |
-| `guid`                    | [GUID][guid]                 | The GUID of the comment.                        |
-| `parent_guid`             | [GUID][guid]                 | The GUID of the parent entity.                  |
-| `text`                    | [Markdown][markdown] (65535) | The comment text.                               |
-| `created_at`              | [Timestamp][timestamp]       | The create timestamp of the comment.            |
-| `author_signature`        | [Signature][signature]       | The signature from the author of the comment.   |
+| Property                  | Type (Length)                | Editable | Description                                     |
+| ------------------------- | ---------------------------- |:--------:| ----------------------------------------------- |
+| `author`                  | [diaspora\* ID][diaspora-id] |    ✘     | The diaspora\* ID of the author of the comment. |
+| `guid`                    | [GUID][guid]                 |    ✘     | The GUID of the comment.                        |
+| `parent_guid`             | [GUID][guid]                 |    ✘     | The GUID of the parent entity.                  |
+| `text`                    | [Markdown][markdown] (65535) |    ✔     | The comment text.                               |
+| `created_at`              | [Timestamp][timestamp]       |    ✘     | The create timestamp of the comment.            |
+| `author_signature`        | [Signature][signature]       |    ✔     | The signature from the author of the comment.   |
 
 ## Optional Properties
 
-| Property             | Type (Length) | Description                                   |
-| -------------------- | ------------- | --------------------------------------------- |
-| `thread_parent_guid` | [GUID][guid]  | The GUID of the parent comment in the thread. |
+| Property             | Type (Length)          | Editable | Description                                   |
+| -------------------- | ---------------------- |:--------:| --------------------------------------------- |
+| `edited_at`          | [Timestamp][timestamp] |    ✔     | The timestamp when the comment was edited.    |
+| `thread_parent_guid` | [GUID][guid]           |    ✘     | The GUID of the parent comment in the thread. |
 
 ## Examples
 

--- a/docs/_entities/event.md
+++ b/docs/_entities/event.md
@@ -8,22 +8,23 @@ See also: [EventParticipation][event_participation]
 
 ## Properties
 
-| Property  | Type (Length)                | Description                                   |
-| --------- | ---------------------------- | --------------------------------------------- |
-| `author`  | [diaspora\* ID][diaspora-id] | The diaspora\* ID of the author of the event. |
-| `guid`    | [GUID][guid]                 | The GUID of the event.                        |
-| `summary` | [String][string] (255)       | The summary of the event.                     |
-| `start`   | [Timestamp][timestamp]       | The start time of the event (in UTC).         |
+| Property  | Type (Length)                | Editable | Description                                   |
+| --------- | ---------------------------- |:--------:| --------------------------------------------- |
+| `author`  | [diaspora\* ID][diaspora-id] |    ✘     | The diaspora\* ID of the author of the event. |
+| `guid`    | [GUID][guid]                 |    ✘     | The GUID of the event.                        |
+| `summary` | [String][string] (255)       |    ✔     | The summary of the event.                     |
+| `start`   | [Timestamp][timestamp]       |    ✔     | The start time of the event (in UTC).         |
 
 ## Optional Properties
 
-| Property      | Type (Length)                | Description                                                                                                                                                                                                                                     |
-| ------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `end`         | [Timestamp][timestamp]       | The end time of the event (in UTC). If missing it is an open-end or a single `all_day` event.                                                                                                                                                   |
-| `all_day`     | [Boolean][boolean]           | `true` if it is an all day event. Time/timezone is ignored. `false` by default.                                                                                                                                                                 |
-| `timezone`    | [Timezone][timezone]         | If the event is fixed to a specific timezone, this can be set. The `start`/`end` timestamps are then displayed in this timezone. This is useful for local events. If missing or empty the timestamps are displayed in the timezone of the user. |
-| `description` | [Markdown][markdown] (65535) | Description of the event.                                                                                                                                                                                                                       |
-| `location`    | [Location][location]         | Location of the event.                                                                                                                                                                                                                          |
+| Property      | Type (Length)                | Editable | Description                                                                                                                                                                                                                                     |
+| ------------- | ---------------------------- |:--------:| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `end`         | [Timestamp][timestamp]       |    ✔     | The end time of the event (in UTC). If missing it is an open-end or a single `all_day` event.                                                                                                                                                   |
+| `all_day`     | [Boolean][boolean]           |    ✔     | `true` if it is an all day event. Time/timezone is ignored. `false` by default.                                                                                                                                                                 |
+| `timezone`    | [Timezone][timezone]         |    ✔     | If the event is fixed to a specific timezone, this can be set. The `start`/`end` timestamps are then displayed in this timezone. This is useful for local events. If missing or empty the timestamps are displayed in the timezone of the user. |
+| `description` | [Markdown][markdown] (65535) |    ✔     | Description of the event.                                                                                                                                                                                                                       |
+| `location`    | [Location][location]         |    ✔     | Location of the event.                                                                                                                                                                                                                          |
+| `edited_at`   | [Timestamp][timestamp]       |    ✔     | The timestamp when the event was edited.                                                                                                                                                                                                        |
 
 ## Examples
 

--- a/docs/_entities/event_participation.md
+++ b/docs/_entities/event_participation.md
@@ -8,14 +8,19 @@ See also: [Relayable][relayable]
 
 ## Properties
 
-| Property                  | Type                         | Description                                                                                                                          |
-| ------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `author`                  | [diaspora\*&nbsp;ID][diaspora-id] | The diaspora\* ID of the author of the event participation.                                                                          |
-| `guid`                    | [GUID][guid]                 | The GUID of the event participation.                                                                                                 |
-| `parent_guid`             | [GUID][guid]                 | The GUID of the [Event][event].                                                                                                      |
-| `status`                  | [String][string]             | The participation status, lowercase string as defined in [RFC 5545, Section 3.2.12][status] (`accepted`, `declined` or `tentative`). |
-| `author_signature`        | [Signature][signature]       | The signature from the author of the event participation.                                                                            |
-| `parent_author_signature` | [Signature][signature]       | The signature from the author of the [Event][event].                                                                                 |
+| Property           | Type                         | Editable | Description                                                                                                                          |
+| ------------------ | ---------------------------- |:--------:| ------------------------------------------------------------------------------------------------------------------------------------ |
+| `author`           | [diaspora\* ID][diaspora-id] |    ✘     | The diaspora\* ID of the author of the event participation.                                                                          |
+| `guid`             | [GUID][guid]                 |    ✘     | The GUID of the event participation.                                                                                                 |
+| `parent_guid`      | [GUID][guid]                 |    ✘     | The GUID of the [Event][event].                                                                                                      |
+| `status`           | [String][string]             |    ✔     | The participation status, lowercase string as defined in [RFC 5545, Section 3.2.12][status] (`accepted`, `declined` or `tentative`). |
+| `author_signature` | [Signature][signature]       |    ✔     | The signature from the author of the event participation.                                                                            |
+
+## Optional Properties
+
+| Property    | Type                   | Editable | Description                                            |
+| ----------- | ---------------------- |:--------:| ------------------------------------------------------ |
+| `edited_at` | [Timestamp][timestamp] |    ✔     | The timestamp when the event participation was edited. |
 
 ## Examples
 
@@ -50,5 +55,6 @@ See also: [Relayable][relayable]
 [string]: {{ site.baseurl }}/federation/types.html#string
 [status]: https://tools.ietf.org/html/rfc5545#section-3.2.12
 [signature]: {{ site.baseurl }}/federation/types.html#signature
+[timestamp]: {{ site.baseurl }}/federation/types.html#timestamp
 [event]: {{ site.baseurl }}/entities/event.html
 [relayable]: {{ site.baseurl }}/federation/relayable.html

--- a/docs/_entities/message.md
+++ b/docs/_entities/message.md
@@ -7,13 +7,19 @@ This entity represents a private message exchanged in private conversation. It c
 
 ## Properties
 
-| Property            | Type (Length)                | Description                                     |
-| ------------------- | ---------------------------- | ----------------------------------------------- |
-| `author`            | [diaspora\* ID][diaspora-id] | The diaspora\* ID of the author of the message. |
-| `guid`              | [GUID][guid]                 | The GUID of the message.                        |
-| `conversation_guid` | [GUID][guid]                 | The GUID of the [Conversation][conversation].   |
-| `text`              | [Markdown][markdown] (65535) | The message text.                               |
-| `created_at`        | [Timestamp][timestamp]       | The create timestamp of the message.            |
+| Property            | Type (Length)                | Editable | Description                                     |
+| ------------------- | ---------------------------- |:--------:| ----------------------------------------------- |
+| `author`            | [diaspora\* ID][diaspora-id] |    ✘     | The diaspora\* ID of the author of the message. |
+| `guid`              | [GUID][guid]                 |    ✘     | The GUID of the message.                        |
+| `conversation_guid` | [GUID][guid]                 |    ✘     | The GUID of the [Conversation][conversation].   |
+| `text`              | [Markdown][markdown] (65535) |    ✔     | The message text.                               |
+| `created_at`        | [Timestamp][timestamp]       |    ✘     | The create timestamp of the message.            |
+
+## Optional Properties
+
+| Property             | Type (Length)          | Editable | Description                                |
+| -------------------- | ---------------------- |:--------:| ------------------------------------------ |
+| `edited_at`          | [Timestamp][timestamp] |    ✔     | The timestamp when the message was edited. |
 
 ## Example
 

--- a/docs/_entities/photo.md
+++ b/docs/_entities/photo.md
@@ -6,23 +6,24 @@ This entity represents a photo. It can be standalone or nested in a [StatusMessa
 
 ## Properties
 
-| Property            | Type (Length)                | Description                                                      |
-| ------------------- | ---------------------------- | ---------------------------------------------------------------- |
-| `author`            | [diaspora\* ID][diaspora-id] | The diaspora\* ID of the author of the photo.                    |
-| `guid`              | [GUID][guid]                 | The GUID of the photo.                                           |
-| `public`            | [Boolean][boolean]           | `true` if the photo is public.                                   |
-| `created_at`        | [Timestamp][timestamp]       | The create timestamp of the photo.                               |
-| `remote_photo_path` | [URL][url]                   | The URL to the photo, without filename (see `remote_photo_name`) |
-| `remote_photo_name` | [String][string] (255)       | The filename of the photo.                                       |
+| Property            | Type (Length)                | Editable | Description                                                      |
+| ------------------- | ---------------------------- |:--------:| ---------------------------------------------------------------- |
+| `author`            | [diaspora\* ID][diaspora-id] |    ✘     | The diaspora\* ID of the author of the photo.                    |
+| `guid`              | [GUID][guid]                 |    ✘     | The GUID of the photo.                                           |
+| `public`            | [Boolean][boolean]           |    ✘     | `true` if the photo is public.                                   |
+| `created_at`        | [Timestamp][timestamp]       |    ✘     | The create timestamp of the photo.                               |
+| `remote_photo_path` | [URL][url]                   |    ✔     | The URL to the photo, without filename (see `remote_photo_name`) |
+| `remote_photo_name` | [String][string] (255)       |    ✔     | The filename of the photo.                                       |
 
 ## Optional Properties
 
-| Property              | Type (Length)            | Description                                                                     |
-| --------------------- | ------------------------ | ------------------------------------------------------------------------------- |
-| `text`                | [String][string] (65535) | Description text for the photo.                                                 |
-| `status_message_guid` | [GUID][guid]             | The GUID of the [StatusMessage][status_message] to which the photo is attached. |
-| `height`              | [Integer][integer]       | The height of the photo in pixels.                                              |
-| `width`               | [Integer][integer]       | The width of the photo in pixels.                                               |
+| Property              | Type (Length)            | Editable | Description                                                                     |
+| --------------------- | ------------------------ |:--------:| ------------------------------------------------------------------------------- |
+| `edited_at`           | [Timestamp][timestamp]   |    ✔     | The timestamp when the photo was edited.                                        |
+| `text`                | [String][string] (65535) |    ✔     | Description text for the photo.                                                 |
+| `status_message_guid` | [GUID][guid]             |    ✘     | The GUID of the [StatusMessage][status_message] to which the photo is attached. |
+| `height`              | [Integer][integer]       |    ✔     | The height of the photo in pixels.                                              |
+| `width`               | [Integer][integer]       |    ✔     | The width of the photo in pixels.                                               |
 
 ## Example
 

--- a/docs/_entities/profile.md
+++ b/docs/_entities/profile.md
@@ -21,33 +21,35 @@ only contain the base profile.
 
 ## Properties
 
-| Property | Type                         | Description                      |
-| -------- | ---------------------------- | -------------------------------- |
-| `author` | [diaspora\* ID][diaspora-id] | The diaspora\* ID of the person. |
+| Property | Type                         | Editable | Description                      |
+| -------- | ---------------------------- |:--------:| -------------------------------- |
+| `author` | [diaspora\* ID][diaspora-id] |    ✘     | The diaspora\* ID of the person. |
 
 ## Optional Properties
 
-| Property           | Type (Length)                | Description                                                                                              |
-| ------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `first_name`       | [Name][name] (32)            | The first name of the person.                                                                            |
-| `last_name`        | [Name][name] (32)            | The last name of the person.                                                                             |
-| `image_url`        | [URL][url] (255)             | The URL to the big avatar (300x300) of the person.                                                       |
-| `image_url_medium` | [URL][url] (255)             | The URL to the medium avatar (100x100) of the person.                                                    |
-| `image_url_small`  | [URL][url] (255)             | The URL to the small avatar (50x50) of the person.                                                       |
-| `bio`              | [Markdown][markdown] (65535) | The description of the person. This field can contain markdown.                                          |
-| `birthday`         | [Date][date]                 | The birthday of the person. The year may be `1004` or less, if the person specifies only day and month.  |
-| `gender`           | [String][string] (255)       | The gender of the person.                                                                                |
-| `location`         | [String][string] (255)       | The location of the person.                                                                              |
-| `searchable`       | [Boolean][boolean]           | `false` if the person doesn't want to be searchable by name.                                             |
-| `public`           | [Boolean][boolean]           | `true` if the profile is visible to everyone.                                                            |
-| `nsfw`             | [Boolean][boolean]           | `true` if all posts of this person should be marked as NSFW.                                             |
-| `tag_string`       | [String][string]             | A list of hashtags for this person, each tag beginning with `#` and seperated by spaces, at most 5 tags. |
+| Property           | Type (Length)                | Editable | Description                                                                                              |
+| ------------------ | ---------------------------- |:--------:| -------------------------------------------------------------------------------------------------------- |
+| `edited_at`        | [Timestamp][timestamp]       |    ✔     | The timestamp when the profile was edited.                                                               |
+| `first_name`       | [Name][name] (32)            |    ✔     | The first name of the person.                                                                            |
+| `last_name`        | [Name][name] (32)            |    ✔     | The last name of the person.                                                                             |
+| `image_url`        | [URL][url] (255)             |    ✔     | The URL to the big avatar (300x300) of the person.                                                       |
+| `image_url_medium` | [URL][url] (255)             |    ✔     | The URL to the medium avatar (100x100) of the person.                                                    |
+| `image_url_small`  | [URL][url] (255)             |    ✔     | The URL to the small avatar (50x50) of the person.                                                       |
+| `bio`              | [Markdown][markdown] (65535) |    ✔     | The description of the person. This field can contain markdown.                                          |
+| `birthday`         | [Date][date]                 |    ✔     | The birthday of the person. The year may be `1004` or less, if the person specifies only day and month.  |
+| `gender`           | [String][string] (255)       |    ✔     | The gender of the person.                                                                                |
+| `location`         | [String][string] (255)       |    ✔     | The location of the person.                                                                              |
+| `searchable`       | [Boolean][boolean]           |    ✔     | `false` if the person doesn't want to be searchable by name.                                             |
+| `public`           | [Boolean][boolean]           |    ✔     | `true` if the profile is visible to everyone.                                                            |
+| `nsfw`             | [Boolean][boolean]           |    ✔     | `true` if all posts of this person should be marked as NSFW.                                             |
+| `tag_string`       | [String][string]             |    ✔     | A list of hashtags for this person, each tag beginning with `#` and seperated by spaces, at most 5 tags. |
 
 ## Example
 
 ~~~xml
 <profile>
   <author>alice@example.org</author>
+  <edited_at>2018-01-23T01:19:56Z</edited_at>
   <first_name>Alice</first_name>
   <last_name>Smith</last_name>
   <image_url>https://example.org/images/thumb_large_a795f872c93309597345.jpg</image_url>
@@ -65,6 +67,7 @@ only contain the base profile.
 ~~~
 
 [diaspora-id]: {{ site.baseurl }}/federation/types.html#diaspora-id
+[timestamp]: {{ site.baseurl }}/federation/types.html#timestamp
 [name]: {{ site.baseurl }}/federation/types.html#name
 [url]: {{ site.baseurl }}/federation/types.html#url
 [date]: {{ site.baseurl }}/federation/types.html#date

--- a/docs/_entities/status_message.md
+++ b/docs/_entities/status_message.md
@@ -6,23 +6,24 @@ This entity represents a reshare of a status message. It inherits from [Post][po
 
 ## Properties
 
-| Property     | Type (Length)                | Description                                            |
-| ------------ | ---------------------------- | ------------------------------------------------------ |
-| `author`     | [diaspora\* ID][diaspora-id] | The diaspora\* ID of the author of the status message. |
-| `guid`       | [GUID][guid]                 | The GUID of the status message.                        |
-| `created_at` | [Timestamp][timestamp]       | The create timestamp of the status message.            |
-| `public`     | [Boolean][boolean]           | `true` if the status message is public.                |
-| `text`       | [Markdown][markdown] (65535) | The status message text.                               |
+| Property     | Type (Length)                | Editable | Description                                            |
+| ------------ | ---------------------------- |:--------:| ------------------------------------------------------ |
+| `author`     | [diaspora\* ID][diaspora-id] |    ✘     | The diaspora\* ID of the author of the status message. |
+| `guid`       | [GUID][guid]                 |    ✘     | The GUID of the status message.                        |
+| `created_at` | [Timestamp][timestamp]       |    ✘     | The create timestamp of the status message.            |
+| `public`     | [Boolean][boolean]           |    ✘     | `true` if the status message is public.                |
+| `text`       | [Markdown][markdown] (65535) |    ✔     | The status message text.                               |
 
 ## Optional Properties
 
-| Property                | Type (Length)          | Description                                                                                                             |
-| ----------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `provider_display_name` | [String][string] (255) | The means by which the author has posted the status message.                                                            |
-| `location`              | [Location][location]   | The Location information of the status message.                                                                         |
-| `photo`                 | [Photo][photo]s        | The attached Photos of the status message, the `status_message_guid` and the `author` need to match the status message. |
-| `poll`                  | [Poll][poll]           | The attached Poll of the status message.                                                                                |
-| `event`                 | [Event][event]         | The attached Event of the status message.                                                                               |
+| Property                | Type (Length)          | Editable | Description                                                                                                             |
+| ----------------------- | ---------------------- |:--------:| ----------------------------------------------------------------------------------------------------------------------- |
+| `edited_at`             | [Timestamp][timestamp] |    ✔     | The timestamp when the status message was edited.                                                                       |
+| `provider_display_name` | [String][string] (255) |    ✘     | The means by which the author has posted the status message.                                                            |
+| `location`              | [Location][location]   |    ✔     | The Location information of the status message.                                                                         |
+| `photo`                 | [Photo][photo]s        |    ✔     | The attached Photos of the status message, the `status_message_guid` and the `author` need to match the status message. |
+| `poll`                  | [Poll][poll]           |    ✘     | The attached Poll of the status message.                                                                                |
+| `event`                 | [Event][event]         |    ✘     | The attached Event of the status message.                                                                               |
 
 ## Examples
 

--- a/lib/diaspora_federation/entities/comment.rb
+++ b/lib/diaspora_federation/entities/comment.rb
@@ -17,6 +17,11 @@ module DiasporaFederation
       #   Comment entity creation time
       #   @return [Time] creation time
       property :created_at, :timestamp, default: -> { Time.now.utc }
+
+      # @!attribute [r] edited_at
+      #   The timestamp when the comment was edited
+      #   @return [Time] edited time
+      property :edited_at, :timestamp, optional: true
     end
   end
 end

--- a/lib/diaspora_federation/entities/event.rb
+++ b/lib/diaspora_federation/entities/event.rb
@@ -16,6 +16,11 @@ module DiasporaFederation
       #   @return [String] guid
       property :guid, :string
 
+      # @!attribute [r] edited_at
+      #   The timestamp when the event was edited
+      #   @return [Time] edited time
+      property :edited_at, :timestamp, optional: true
+
       # @!attribute [r] summary
       #   The summary of the event
       #   @return [String] event summary

--- a/lib/diaspora_federation/entities/event_participation.rb
+++ b/lib/diaspora_federation/entities/event_participation.rb
@@ -14,6 +14,11 @@ module DiasporaFederation
       #   "accepted", "declined" or "tentative"
       #   @return [String] event participation status
       property :status, :string
+
+      # @!attribute [r] edited_at
+      #   The timestamp when the event participation was edited
+      #   @return [Time] edited time
+      property :edited_at, :timestamp, optional: true
     end
   end
 end

--- a/lib/diaspora_federation/entities/message.rb
+++ b/lib/diaspora_federation/entities/message.rb
@@ -26,6 +26,11 @@ module DiasporaFederation
       #   @return [Time] creation time
       property :created_at, :timestamp, default: -> { Time.now.utc }
 
+      # @!attribute [r] edited_at
+      #   The timestamp when the message was edited
+      #   @return [Time] edited time
+      property :edited_at, :timestamp, optional: true
+
       # @!attribute [r] conversation_guid
       #   Guid of a conversation this message belongs to
       #   @see Conversation#guid

--- a/lib/diaspora_federation/entities/photo.rb
+++ b/lib/diaspora_federation/entities/photo.rb
@@ -26,6 +26,11 @@ module DiasporaFederation
       #   @return [Time] creation time
       property :created_at, :timestamp, default: -> { Time.now.utc }
 
+      # @!attribute [r] edited_at
+      #   The timestamp when the photo was edited
+      #   @return [Time] edited time
+      property :edited_at, :timestamp, optional: true
+
       # @!attribute [r] remote_photo_path
       #   An url of the photo on a remote server
       #   @return [String] remote photo url

--- a/lib/diaspora_federation/entities/profile.rb
+++ b/lib/diaspora_federation/entities/profile.rb
@@ -14,6 +14,11 @@ module DiasporaFederation
       #   @return [String] diaspora* ID
       property :author, :string, alias: :diaspora_id, xml_name: :diaspora_handle
 
+      # @!attribute [r] edited_at
+      #   The timestamp when the profile was edited
+      #   @return [Time] edited time
+      property :edited_at, :timestamp, optional: true
+
       # @!attribute [r] first_name
       #   @deprecated We decided to only use one name field, these should be removed
       #     in later iterations (will affect older diaspora* installations).

--- a/lib/diaspora_federation/entities/status_message.rb
+++ b/lib/diaspora_federation/entities/status_message.rb
@@ -11,6 +11,11 @@ module DiasporaFederation
       #   @return [String] text of the status message
       property :text, :string, xml_name: :raw_message
 
+      # @!attribute [r] edited_at
+      #   The timestamp when the status message was edited
+      #   @return [Time] edited time
+      property :edited_at, :timestamp, optional: true
+
       # @!attribute [r] photos
       #   Optional photos attached to the status message
       #   @return [[Entities::Photo]] photos

--- a/lib/diaspora_federation/test/factories.rb
+++ b/lib/diaspora_federation/test/factories.rb
@@ -55,6 +55,7 @@ module DiasporaFederation
 
       Fabricator(:profile_entity, class_name: DiasporaFederation::Entities::Profile) do
         author { Fabricate.sequence(:diaspora_id) }
+        edited_at { Time.now.utc }
         first_name "my name"
         last_name nil
         image_url "/assets/user/default.png"

--- a/lib/diaspora_federation/test/factories.rb
+++ b/lib/diaspora_federation/test/factories.rb
@@ -81,6 +81,7 @@ module DiasporaFederation
         author { Fabricate.sequence(:diaspora_id) }
         public true
         created_at { Time.now.utc }
+        edited_at { Time.now.utc + 3600 }
         remote_photo_path "https://diaspora.example.tld/uploads/images/"
         remote_photo_name "f2a41e9d2db4d9a199c8.jpg"
         text "what you see here..."
@@ -107,6 +108,7 @@ module DiasporaFederation
         guid { Fabricate.sequence(:guid) }
         public true
         created_at { Time.now.utc }
+        edited_at { Time.now.utc + 3600 }
       end
 
       Fabricator(:contact_entity, class_name: DiasporaFederation::Entities::Contact) do
@@ -121,6 +123,8 @@ module DiasporaFederation
         author { Fabricate.sequence(:diaspora_id) }
         guid { Fabricate.sequence(:guid) }
         text "this is a very informative comment"
+        created_at { Time.now.utc }
+        edited_at { Time.now.utc + 3600 }
       end
 
       Fabricator(:like_entity, class_name: DiasporaFederation::Entities::Like, from: :relayable_entity) do
@@ -144,6 +148,7 @@ module DiasporaFederation
         author { Fabricate.sequence(:diaspora_id) }
         text "this is a very informative text"
         created_at { Time.now.utc }
+        edited_at { Time.now.utc + 3600 }
         conversation_guid { Fabricate.sequence(:guid) }
       end
 

--- a/lib/diaspora_federation/test/factories.rb
+++ b/lib/diaspora_federation/test/factories.rb
@@ -189,6 +189,7 @@ module DiasporaFederation
       Fabricator(:event_entity, class_name: DiasporaFederation::Entities::Event) do |f|
         author { Fabricate.sequence(:diaspora_id) }
         guid { Fabricate.sequence(:guid) }
+        edited_at { Time.now.utc }
         summary "Cool event"
         description "You need to see this!"
         start { change_time(Time.now.utc, min: 0) - 3600 }
@@ -202,6 +203,7 @@ module DiasporaFederation
         author { Fabricate.sequence(:diaspora_id) }
         guid { Fabricate.sequence(:guid) }
         status "accepted"
+        edited_at { Time.now.utc }
       end
 
       Fabricator(:related_entity, class_name: DiasporaFederation::Entities::RelatedEntity) do

--- a/spec/lib/diaspora_federation/entities/account_migration_spec.rb
+++ b/spec/lib/diaspora_federation/entities/account_migration_spec.rb
@@ -9,6 +9,7 @@ module DiasporaFederation
       hash.tap {|hash|
         properties = described_class.new(hash).send(:enriched_properties)
         hash[:signature] = properties[:signature]
+        hash[:profile] = Entities::Profile.new(hash[:profile].to_h.tap {|profile| profile[:edited_at] = nil })
       }
     }
     let(:signature_data) { "AccountMigration:#{old_diaspora_id}:#{new_diaspora_id}" }

--- a/spec/lib/diaspora_federation/entities/comment_spec.rb
+++ b/spec/lib/diaspora_federation/entities/comment_spec.rb
@@ -8,8 +8,7 @@ module DiasporaFederation
           :comment_entity,
           author:      alice.diaspora_id,
           parent_guid: parent.guid,
-          parent:      parent_entity,
-          created_at:  Time.now.utc
+          parent:      parent_entity
         ).tap {|hash| add_signatures(hash) }
     }
 
@@ -20,6 +19,7 @@ module DiasporaFederation
   <parent_guid>#{parent.guid}</parent_guid>
   <text>#{data[:text]}</text>
   <created_at>#{data[:created_at].utc.iso8601}</created_at>
+  <edited_at>#{data[:edited_at].utc.iso8601}</edited_at>
   <author_signature>#{data[:author_signature]}</author_signature>
   <parent_author_signature>#{data[:parent_author_signature]}</parent_author_signature>
 </comment>
@@ -34,14 +34,16 @@ XML
     "parent_guid": "#{parent.guid}",
     "author_signature": "#{data[:author_signature]}",
     "text": "#{data[:text]}",
-    "created_at": "#{data[:created_at].iso8601}"
+    "created_at": "#{data[:created_at].iso8601}",
+    "edited_at": "#{data[:edited_at].iso8601}"
   },
   "property_order": [
     "author",
     "guid",
     "parent_guid",
     "text",
-    "created_at"
+    "created_at",
+    "edited_at"
   ]
 }
 JSON

--- a/spec/lib/diaspora_federation/entities/event_participation_spec.rb
+++ b/spec/lib/diaspora_federation/entities/event_participation_spec.rb
@@ -17,6 +17,7 @@ module DiasporaFederation
   <guid>#{data[:guid]}</guid>
   <parent_guid>#{parent.guid}</parent_guid>
   <status>#{data[:status]}</status>
+  <edited_at>#{data[:edited_at].utc.iso8601}</edited_at>
   <author_signature>#{data[:author_signature]}</author_signature>
   <parent_author_signature>#{data[:parent_author_signature]}</parent_author_signature>
 </event_participation>

--- a/spec/lib/diaspora_federation/entities/event_spec.rb
+++ b/spec/lib/diaspora_federation/entities/event_spec.rb
@@ -9,6 +9,7 @@ module DiasporaFederation
 <event>
   <author>#{data[:author]}</author>
   <guid>#{data[:guid]}</guid>
+  <edited_at>#{data[:edited_at].utc.iso8601}</edited_at>
   <summary>#{data[:summary]}</summary>
   <description>#{data[:description]}</description>
   <start>#{data[:start].utc.iso8601}</start>

--- a/spec/lib/diaspora_federation/entities/message_spec.rb
+++ b/spec/lib/diaspora_federation/entities/message_spec.rb
@@ -8,6 +8,7 @@ module DiasporaFederation
   <guid>#{data[:guid]}</guid>
   <text>#{data[:text]}</text>
   <created_at>#{data[:created_at].utc.iso8601}</created_at>
+  <edited_at>#{data[:edited_at].utc.iso8601}</edited_at>
   <conversation_guid>#{data[:conversation_guid]}</conversation_guid>
 </message>
 XML

--- a/spec/lib/diaspora_federation/entities/person_spec.rb
+++ b/spec/lib/diaspora_federation/entities/person_spec.rb
@@ -9,6 +9,7 @@ module DiasporaFederation
   <url>#{data[:url]}</url>
   <profile>
     <author>#{data[:profile].author}</author>
+    <edited_at>#{data[:profile].edited_at.utc.iso8601}</edited_at>
     <first_name>#{data[:profile].first_name}</first_name>
     <image_url>#{data[:profile].image_url}</image_url>
     <image_url_medium>#{data[:profile].image_url}</image_url_medium>

--- a/spec/lib/diaspora_federation/entities/photo_spec.rb
+++ b/spec/lib/diaspora_federation/entities/photo_spec.rb
@@ -8,6 +8,7 @@ module DiasporaFederation
   <author>#{data[:author]}</author>
   <public>#{data[:public]}</public>
   <created_at>#{data[:created_at].utc.iso8601}</created_at>
+  <edited_at>#{data[:edited_at].utc.iso8601}</edited_at>
   <remote_photo_path>#{data[:remote_photo_path]}</remote_photo_path>
   <remote_photo_name>#{data[:remote_photo_name]}</remote_photo_name>
   <text>#{data[:text]}</text>
@@ -25,6 +26,7 @@ XML
     "author": "#{data[:author]}",
     "public": #{data[:public]},
     "created_at": "#{data[:created_at].utc.iso8601}",
+    "edited_at": "#{data[:edited_at].iso8601}",
     "remote_photo_path": "#{data[:remote_photo_path]}",
     "remote_photo_name": "#{data[:remote_photo_name]}",
     "text": "#{data[:text]}",

--- a/spec/lib/diaspora_federation/entities/profile_spec.rb
+++ b/spec/lib/diaspora_federation/entities/profile_spec.rb
@@ -5,6 +5,7 @@ module DiasporaFederation
     let(:xml) { <<-XML }
 <profile>
   <author>#{data[:author]}</author>
+  <edited_at>#{data[:edited_at].utc.iso8601}</edited_at>
   <first_name>#{data[:first_name]}</first_name>
   <image_url>#{data[:image_url]}</image_url>
   <image_url_medium>#{data[:image_url]}</image_url_medium>
@@ -25,6 +26,7 @@ XML
   "entity_type": "profile",
   "entity_data": {
     "author": "#{data[:author]}",
+    "edited_at": "#{data[:edited_at].iso8601}",
     "first_name": "#{data[:first_name]}",
     "image_url": "#{data[:image_url]}",
     "image_url_medium": "#{data[:image_url]}",

--- a/spec/lib/diaspora_federation/entities/status_message_spec.rb
+++ b/spec/lib/diaspora_federation/entities/status_message_spec.rb
@@ -22,11 +22,13 @@ module DiasporaFederation
   <public>#{data[:public]}</public>
   <provider_display_name>#{data[:provider_display_name]}</provider_display_name>
   <text>#{data[:text]}</text>
+  <edited_at>#{data[:edited_at].utc.iso8601}</edited_at>
   <photo>
     <guid>#{photo1.guid}</guid>
     <author>#{photo1.author}</author>
     <public>#{photo1.public}</public>
     <created_at>#{photo1.created_at.utc.iso8601}</created_at>
+    <edited_at>#{photo1.edited_at.utc.iso8601}</edited_at>
     <remote_photo_path>#{photo1.remote_photo_path}</remote_photo_path>
     <remote_photo_name>#{photo1.remote_photo_name}</remote_photo_name>
     <text>#{photo1.text}</text>
@@ -39,6 +41,7 @@ module DiasporaFederation
     <author>#{photo2.author}</author>
     <public>#{photo2.public}</public>
     <created_at>#{photo2.created_at.utc.iso8601}</created_at>
+    <edited_at>#{photo2.edited_at.utc.iso8601}</edited_at>
     <remote_photo_path>#{photo2.remote_photo_path}</remote_photo_path>
     <remote_photo_name>#{photo2.remote_photo_name}</remote_photo_name>
     <text>#{photo2.text}</text>
@@ -64,6 +67,7 @@ XML
     "public": #{data[:public]},
     "provider_display_name": "#{data[:provider_display_name]}",
     "text": "#{data[:text]}",
+    "edited_at": "#{data[:edited_at].iso8601}",
     "photos": [
       {
         "entity_type": "photo",
@@ -72,6 +76,7 @@ XML
           "author": "#{photo1.author}",
           "public": #{photo1.public},
           "created_at": "#{photo1.created_at.utc.iso8601}",
+          "edited_at": "#{photo1.edited_at.utc.iso8601}",
           "remote_photo_path": "#{photo1.remote_photo_path}",
           "remote_photo_name": "#{photo1.remote_photo_name}",
           "text": "#{photo1.text}",
@@ -87,6 +92,7 @@ XML
           "author": "#{photo2.author}",
           "public": #{photo2.public},
           "created_at": "#{photo2.created_at.utc.iso8601}",
+          "edited_at": "#{photo2.edited_at.utc.iso8601}",
           "remote_photo_path": "#{photo2.remote_photo_path}",
           "remote_photo_name": "#{photo2.remote_photo_name}",
           "text": "#{photo2.text}",


### PR DESCRIPTION
I started with this some time ago (and already discussed parts of it with @annando over a year ago), but didn't have the time to finish it until now.

This adds basic edit features to the protocol:
* I added an `edited_at` property to all entities with a `text` property to make them editable in the future. It's an optional property, so when it's missing, it's the first unedited original and it's only present when it's actually edited content.

   This is backward compatible with current diaspora versions, because receiving a second "duplicate" of the same post (same `guid`) would just be ignored. But others can handle the edit.

    It's up to the implementation if they want to store each version (and display diffs in the frontend) or just overwrite it and keep the latest version. Both is possible with this protocol spec.

* I also added an `edited_at` property to the `profile` entity, which is already editable. But with this property we can make sure that we don't overwrite newer information by receiving an older message (for example when it was stuck and later retried).

* And last I added it to `event`s and `event_participation`s too, mainly because of the same reason as for the `profile`. People need to be able to change their participation state, but we need to make sure to always keep the latest.

   Same for the `event` itself: maybe some important information needs to be changed in the description, and we need to make sure to always have the latest. It's again up to the implementation if they want to keep the history for the description or only the latest version.

Not all properties are editable (for example you can't change the `guid` or the `author`), I marked that for editable entities in the documentation.

Related to: diaspora/diaspora#1762