### PR TITLE
Fix link to PHP implementation in Friendica

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,4 +22,4 @@ The [Friendica][friendica] project also has [its implementation in PHP][phpimple
 [entities]: {{ site.baseurl }}/entities/
 [github]: https://github.com/diaspora/diaspora_federation
 [friendica]: https://github.com/friendica/friendica
-[phpimplementation]: https://github.com/friendica/friendica/blob/master/include/diaspora.php
+[phpimplementation]: https://github.com/friendica/friendica/blob/develop/src/Protocol/Diaspora.php


### PR DESCRIPTION
The link was broken after this [commit].(https://github.com/friendica/friendica/commit/6189f6c8e76305ae5a29a685e3ec5a418ff92941#diff-4bca58fcd8a76a0c052d7ac361872b61)