### PR TITLE
json schema: fix misplaced "required" property

### DIFF
--- a/lib/diaspora_federation/schemas/federation_entities.json
+++ b/lib/diaspora_federation/schemas/federation_entities.json
@@ -164,11 +164,11 @@
           "required": [
             "guid", "public", "created_at"
           ]
-        },
-        "required": [
-          "entity_type", "entity_data"
-        ]
-      }
+        }
+      },
+      "required": [
+        "entity_type", "entity_data"
+      ]
     },
 
     "status_message": {
@@ -232,9 +232,9 @@
             "root_guid": {"$ref": "#/definitions/guid"}
           },
           "required": ["author", "guid", "created_at", "root_author", "root_guid"]
-        },
-        "required": ["entity_type", "entity_data"]
-      }
+        }
+      },
+      "required": ["entity_type", "entity_data"]
     },
 
     "profile": {


### PR DESCRIPTION
I tried to run JSON schema validation using https://github.com/epoberezkin/ajv library (JS). It revealed a bug in our schema, that the `"required"` property was placed inside `"properties"` while it must be on the same level. It was in post and reshare description.