### PR TITLE
Update faraday and faraday_middleware to 1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     diaspora_federation (0.2.6)
-      faraday (>= 0.9.0, < 0.18.0)
-      faraday_middleware (>= 0.10.0, < 0.14.0)
+      faraday (~> 1.0)
+      faraday_middleware (~> 1.0)
       nokogiri (~> 1.6, >= 1.6.8)
       typhoeus (~> 1.0)
       valid (~> 1.0)
@@ -54,10 +54,21 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     fabrication (2.20.2)
-    faraday (0.17.0)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.13.1)
-      faraday (>= 0.7.4, < 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     ffi (1.11.1)
     formatador (0.2.5)
     fuubar (2.4.1)
@@ -197,6 +208,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.4)
     rugged (0.28.3.1)
     safe_yaml (1.0.5)
     sawyer (0.8.2)
@@ -215,7 +227,7 @@ GEM
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -260,4 +272,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/diaspora_federation.gemspec
+++ b/diaspora_federation.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "~> 2.5"
 
-  s.add_dependency "faraday", ">= 0.9.0", "< 0.18.0"
-  s.add_dependency "faraday_middleware", ">= 0.10.0", "< 0.14.0"
+  s.add_dependency "faraday", "~> 1.0"
+  s.add_dependency "faraday_middleware", "~> 1.0"
   s.add_dependency "nokogiri", "~> 1.6", ">= 1.6.8"
   s.add_dependency "typhoeus", "~> 1.0"
   s.add_dependency "valid", "~> 1.0"

--- a/lib/diaspora_federation/http_client.rb
+++ b/lib/diaspora_federation/http_client.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "faraday"
-require "faraday_middleware/response/follow_redirects"
+require "faraday_middleware"
 
 module DiasporaFederation
   # A wrapper for {https://github.com/lostisland/faraday Faraday}
@@ -32,7 +32,7 @@ module DiasporaFederation
       }
 
       @connection = Faraday::Connection.new(options) do |builder|
-        builder.use FaradayMiddleware::FollowRedirects, limit: DiasporaFederation.http_redirect_limit
+        builder.response :follow_redirects, limit: DiasporaFederation.http_redirect_limit
         builder.adapter Faraday.default_adapter
       end
 

--- a/test/gemfiles/no-rails.Gemfile.lock
+++ b/test/gemfiles/no-rails.Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ../..
   specs:
     diaspora_federation (0.2.6)
-      faraday (>= 0.9.0, < 0.18.0)
-      faraday_middleware (>= 0.10.0, < 0.14.0)
+      faraday (~> 1.0)
+      faraday_middleware (~> 1.0)
       nokogiri (~> 1.6, >= 1.6.8)
       typhoeus (~> 1.0)
       valid (~> 1.0)
@@ -25,10 +25,21 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     fabrication (2.20.2)
-    faraday (0.17.0)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.13.1)
-      faraday (>= 0.7.4, < 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     ffi (1.11.1)
     fuubar (2.4.1)
       rspec-core (~> 3.0)
@@ -67,6 +78,7 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.4)
     safe_yaml (1.0.5)
     simplecov (0.17.1)
       docile (~> 1.1)
@@ -76,7 +88,7 @@ GEM
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
     systemu (2.6.5)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
     uuid (2.3.9)
       macaddr (~> 1.0)
@@ -105,4 +117,4 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4


### PR DESCRIPTION
Closes #115 

1 test is failing

```

  1) DiasporaFederation::HttpClient.get follows redirects not more than 4 times
     Failure/Error: expect { HttpClient.get("http://www.example.com") }.to raise_error FaradayMiddleware::RedirectLimitReached

     NameError:
       uninitialized constant FaradayMiddleware::RedirectLimitReached
     # ./spec/lib/diaspora_federation/http_client_spec.rb:36:in `block (3 levels) in <module:DiasporaFederation>'
```