### PR TITLE
Only parse each nested element name once

### DIFF
--- a/lib/diaspora_federation/parsers/xml_parser.rb
+++ b/lib/diaspora_federation/parsers/xml_parser.rb
@@ -14,7 +14,7 @@ module DiasporaFederation
       def parse(root_node)
         from_xml_sanity_validation(root_node)
 
-        hash = root_node.element_children.map {|child|
+        hash = root_node.element_children.uniq(&:name).map {|child|
           property, type = find_property_for(child.name)
           if property
             value = parse_element_from_node(child.name, type, root_node)

--- a/spec/lib/diaspora_federation/parsers/xml_parser_spec.rb
+++ b/spec/lib/diaspora_federation/parsers/xml_parser_spec.rb
@@ -123,6 +123,14 @@ module DiasporaFederation
           expect(parsed[0][:multi].first.to_h).to eq(child_entity2.to_h)
           expect(parsed[0][:asdf]).to eq("QWERT")
         end
+
+        it "parses array entities only once" do
+          expect(Entities::OtherEntity).to receive(:from_xml).twice.and_call_original
+
+          parsed = Parsers::XmlParser.new(Entities::TestNestedEntity).parse(nested_payload)
+
+          expect(parsed[0][:multi]).to have(2).items
+        end
       end
 
       it "doesn't drop extra properties" do


### PR DESCRIPTION
A child elements should only appear once or it is part of a nested array (photos, poll answers). So each element name only needs to be parsed once, because the way `parse_array_from_node` works is, that it already parses the full array with one call, so calling it multiple times again parses the full array a second time.