### PR TITLE
Disable forgery protection for ReceiveController

### DIFF
--- a/app/controllers/diaspora_federation/receive_controller.rb
+++ b/app/controllers/diaspora_federation/receive_controller.rb
@@ -5,6 +5,8 @@ require_dependency "diaspora_federation/application_controller"
 module DiasporaFederation
   # This controller processes receiving messages.
   class ReceiveController < ApplicationController
+    skip_forgery_protection
+
     # Receives public messages
     #
     # POST /receive/public

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,11 @@ RSpec.configure do |config|
     expect_config.syntax = :expect
   end
 
-  unless defined?(::Rails)
+  if defined?(::Rails)
+    config.before(:each, type: :controller) do
+      ActionController::Base.allow_forgery_protection = true
+    end
+  else
     config.exclude_pattern = "**/controllers/**/*_spec.rb, **/routing/**/*_spec.rb"
     config.filter_run_excluding rails: true
   end


### PR DESCRIPTION
This is enabled by default since rails 5.2, but it doesn't make sense for the `/receive/` routes, because they are called without a session and without a token.